### PR TITLE
upgrade to Go 1.26 and x/mod v0.37.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/norman-abramovitz/modrot
 
-go 1.25.0
+go 1.26.4
 
-require golang.org/x/mod v0.34.0
+require golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
-golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=


### PR DESCRIPTION
## Summary
- Bump `golang.org/x/mod` v0.34.0 → v0.37.0 (latest; the module's only dependency)
- Bump the `go` directive 1.25.0 → 1.26.4, required by x/mod v0.37.0

## Verification
- `make verify` passes: tidy, lint/check, tests, and all security scans (govulncheck, trivy, gosec, gitleaks) clean
- `go mod verify`: all modules verified