### PR TITLE
Add SARIF output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ $ modrot --sarif --deprecated > modrot.sarif
     sarif_file: modrot.sarif
 ```
 
-The `|| true` keeps the workflow running when modrot exits 1 on archived findings, so the upload step still runs. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the scanned `go.mod` file (with `--recursive`, to each go.mod in the tree). Run modrot from the repository root so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
+The `|| true` keeps the workflow running when modrot exits 1 on archived findings, so the upload step still runs. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the scanned `go.mod` file (with `--recursive`, to each go.mod in the tree). SARIF paths are always relative to the current working directory, so run modrot from the repository root — e.g. `modrot --recursive --sarif . > modrot.sarif` — so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
 
 **Sorting** — sort archived dependencies by field and direction. Append `:asc` or `:desc` to control order. Each field has a natural default:
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ If no path is given, looks for `go.mod` in the current directory. You can also p
 
 | Flag | Description |
 |------|-------------|
-| `--format FORMAT` | Output format: `table` (default), `json`, `markdown`, `mermaid`, `quickfix` |
+| `--format FORMAT` | Output format: `table` (default), `json`, `markdown`, `mermaid`, `quickfix`, `sarif` |
 | `--json` | Output as JSON (alias for `--format=json`) |
 | `--markdown` | Output as GitHub-Flavored Markdown (alias for `--format=markdown`) |
 | `--mermaid` | Output Mermaid flowchart diagram (alias for `--format=mermaid`) |
 | `--quickfix` | Output `file:line:module` for editor quickfix (alias for `--format=quickfix`) |
+| `--sarif` | Output SARIF 2.1.0 for GitHub code scanning (alias for `--format=sarif`) |
 
 **Filtering:**
 
@@ -395,6 +396,22 @@ $ modrot --markdown
 
 Combines with `--tree`, `--files`, `--stale`, and `--all`.
 
+**SARIF** — upload findings to GitHub code scanning so archived and
+deprecated dependencies appear in the repository's Security tab:
+
+```
+$ modrot --sarif --deprecated > modrot.sarif
+```
+
+```yaml
+- run: modrot --sarif --deprecated > modrot.sarif || true
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: modrot.sarif
+```
+
+The `|| true` keeps the workflow running when modrot exits 1 on archived findings, so the upload step still runs. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the scanned `go.mod` file (with `--recursive`, to each go.mod in the tree). Run modrot from the repository root so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
+
 **Sorting** — sort archived dependencies by field and direction. Append `:asc` or `:desc` to control order. Each field has a natural default:
 
 | Value | Result | Default? |
@@ -435,7 +452,7 @@ $ modrot --no-color                      # Disable colors entirely
 $ NO_COLOR=1 modrot                      # Also disables colors
 ```
 
-Colors apply to archived and stale table output only (not JSON, markdown, mermaid, or quickfix).
+Colors apply to archived and stale table output only (not JSON, markdown, mermaid, quickfix, or SARIF).
 
 ### Filtering and ignoring
 

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import "time"
 // Created once after flag parsing; passed by pointer to all functions.
 type Config struct {
 	// Output
-	OutputFormat string // "table", "json", "markdown", "mermaid", "quickfix"
+	OutputFormat string // "table", "json", "markdown", "mermaid", "quickfix", "sarif"
 	DateFmt      string // "2006-01-02" or "2006-01-02 15:04:05"
 
 	// Filtering

--- a/main.go
+++ b/main.go
@@ -52,11 +52,12 @@ func parseFlags() *Config {
 	reorderArgs()
 
 	// Output format flags
-	formatFlag := flag.String("format", "table", "Output format: table, json, markdown, mermaid, quickfix")
+	formatFlag := flag.String("format", "table", "Output format: table, json, markdown, mermaid, quickfix, sarif")
 	jsonFlag := flag.Bool("json", false, "Output as JSON (alias for --format=json)")
 	markdownFlag := flag.Bool("markdown", false, "Output as GitHub-flavored Markdown (alias for --format=markdown)")
 	mermaidFlag := flag.Bool("mermaid", false, "Output Mermaid flowchart diagram (alias for --format=mermaid)")
 	quickfixFlag := flag.Bool("quickfix", false, "Output file:line:module for editor quickfix (alias for --format=quickfix)")
+	sarifFlag := flag.Bool("sarif", false, "Output SARIF 2.1.0 for GitHub code scanning (alias for --format=sarif)")
 
 	// Filtering flags
 	directOnly := flag.Bool("direct-only", false, "Only check direct dependencies")
@@ -98,11 +99,12 @@ dependencies as a table. Exits 1 if any are found (useful for CI).
 Flags can appear before or after the path argument.
 
 Output format:
-  --format string       Output format: table, json, markdown, mermaid, quickfix (default "table")
+  --format string       Output format: table, json, markdown, mermaid, quickfix, sarif (default "table")
   --json                Output as JSON (alias for --format=json)
   --markdown            Output as GitHub-flavored Markdown (alias for --format=markdown)
   --mermaid             Output Mermaid flowchart diagram (alias for --format=mermaid)
   --quickfix            Output file:line:module for editor quickfix (alias for --format=quickfix)
+  --sarif               Output SARIF 2.1.0 for GitHub code scanning (alias for --format=sarif)
 
 Filtering:
   --direct-only         Only check direct dependencies (useful for CI)
@@ -154,6 +156,7 @@ Examples:
   modrot --markdown --all --deprecated       Markdown for release notes
   modrot --json | jq '.archived[].module'    Scripting with JSON output
   modrot --recursive /path/to/monorepo       Scan all go.mod files in a tree
+  modrot --sarif --deprecated > modrot.sarif     SARIF for GitHub code scanning
 `)
 	}
 	flag.Parse()
@@ -186,6 +189,8 @@ Examples:
 		cfg.OutputFormat = "mermaid"
 	case *quickfixFlag:
 		cfg.OutputFormat = "quickfix"
+	case *sarifFlag:
+		cfg.OutputFormat = "sarif"
 	}
 
 	// Auto-enable rules
@@ -194,6 +199,11 @@ Examples:
 	}
 	if cfg.OutputFormat == "mermaid" {
 		*treeFlag = true
+	}
+	if cfg.OutputFormat == "sarif" {
+		// SARIF is a flat findings document; tree mode would route output
+		// to formats that cannot carry it.
+		*treeFlag = false
 	}
 
 	cfg.DirectOnly = *directOnly
@@ -350,7 +360,7 @@ func runSingleModule(cfg *Config, inputPath string) int {
 	}
 
 	// Output
-	outputFlat(cfg, results, nonGitHubModules, fileMatches, deprecatedModules, stale, ignoredResults, ignoreList)
+	outputFlat(cfg, filepath.ToSlash(relPath), results, nonGitHubModules, fileMatches, deprecatedModules, stale, ignoredResults, ignoreList)
 
 	return exitCode(hasArchived)
 }
@@ -454,7 +464,7 @@ func outputTree(cfg *Config, results []RepoStatus, graph map[string][]string, al
 }
 
 // outputFlat dispatches non-tree output to the appropriate format.
-func outputFlat(cfg *Config, results []RepoStatus, nonGitHubModules []Module,
+func outputFlat(cfg *Config, gomodRel string, results []RepoStatus, nonGitHubModules []Module,
 	fileMatches map[string][]FileMatch, deprecatedModules []Module,
 	stale []RepoStatus, ignoredResults []RepoStatus, ignoreList *IgnoreList) {
 
@@ -463,6 +473,9 @@ func outputFlat(cfg *Config, results []RepoStatus, nonGitHubModules []Module,
 		if fileMatches != nil {
 			PrintFilesPlain(results, fileMatches)
 		}
+	case "sarif":
+		PrintSARIF([]SARIFInput{{GomodURI: gomodRel, Results: results, Deprecated: deprecatedModules}})
+		return
 	case "json":
 		PrintJSON(cfg, results, nonGitHubModules, fileMatches, stale, deprecatedModules)
 	case "markdown":

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ Examples:
   modrot --markdown --all --deprecated       Markdown for release notes
   modrot --json | jq '.archived[].module'    Scripting with JSON output
   modrot --recursive /path/to/monorepo       Scan all go.mod files in a tree
-  modrot --sarif --deprecated > modrot.sarif     SARIF for GitHub code scanning
+  modrot --sarif > modrot.sarif              SARIF for GitHub code scanning
 `)
 	}
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -313,6 +313,12 @@ func runSingleModule(cfg *Config, inputPath string) int {
 
 	if len(githubModules) == 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "No GitHub modules found in %s\n", gomodPath)
+		if cfg.OutputFormat == "sarif" {
+			PrintSARIF([]SARIFInput{{
+				GomodURI:   filepath.ToSlash(relPath),
+				Deprecated: collectDeprecated(cfg, allModules),
+			}})
+		}
 		return 0
 	}
 

--- a/recursive.go
+++ b/recursive.go
@@ -72,6 +72,17 @@ type moduleInfo struct {
 	nonGHModules  []Module
 }
 
+// sarifGomodURI returns gomodPath relative to cwd, with forward slashes,
+// for use as a SARIF artifact location. Falls back to gomodPath unchanged
+// if it cannot be made relative to cwd.
+func sarifGomodURI(cwd, gomodPath string) string {
+	uri := gomodPath
+	if rel, err := filepath.Rel(cwd, gomodPath); err == nil {
+		uri = rel
+	}
+	return filepath.ToSlash(uri)
+}
+
 // getDeprecatedModules returns modules with non-empty Deprecated field,
 // respecting the directOnly filter. Returns nil if deprecatedMode is false.
 func getDeprecatedModules(allModules []Module, directOnly bool, deprecatedMode bool) []Module {
@@ -175,12 +186,8 @@ func runRecursive(rootDir string, cfg *Config) int {
 			cwd, _ := os.Getwd()
 			inputs := make([]SARIFInput, 0, len(modules))
 			for _, mi := range modules {
-				uri := mi.gomodPath
-				if rel, relErr := filepath.Rel(cwd, mi.gomodPath); relErr == nil {
-					uri = rel
-				}
 				inputs = append(inputs, SARIFInput{
-					GomodURI:   filepath.ToSlash(uri),
+					GomodURI:   sarifGomodURI(cwd, mi.gomodPath),
 					Deprecated: getDeprecatedModules(mi.allModules, cfg.DirectOnly, cfg.Deprecated),
 				})
 			}
@@ -353,6 +360,7 @@ func runRecursiveJSON(modules []moduleInfo, statusMap map[string]RepoStatus, cfg
 func runRecursiveSARIF(modules []moduleInfo, statusMap map[string]RepoStatus, cfg *Config) bool {
 	hasAnyArchived := false
 	inputs := make([]SARIFInput, 0, len(modules))
+	cwd, _ := os.Getwd()
 
 	for _, mi := range modules {
 		results := applyStatus(mi.githubModules, statusMap)
@@ -367,7 +375,7 @@ func runRecursiveSARIF(modules []moduleInfo, statusMap map[string]RepoStatus, cf
 		}
 
 		inputs = append(inputs, SARIFInput{
-			GomodURI:   filepath.ToSlash(mi.relPath),
+			GomodURI:   sarifGomodURI(cwd, mi.gomodPath),
 			Results:    results,
 			Deprecated: getDeprecatedModules(mi.allModules, cfg.DirectOnly, cfg.Deprecated),
 		})

--- a/recursive.go
+++ b/recursive.go
@@ -196,6 +196,8 @@ func runRecursive(rootDir string, cfg *Config) int {
 		hasAnyArchived = runRecursiveQuickfix(modules, statusMap, cfg)
 	case "json":
 		hasAnyArchived = runRecursiveJSON(modules, statusMap, cfg)
+	case "sarif":
+		hasAnyArchived = runRecursiveSARIF(modules, statusMap, cfg)
 	case "markdown":
 		hasAnyArchived = runRecursiveMarkdown(modules, statusMap, cfg)
 	default:
@@ -328,6 +330,35 @@ func runRecursiveJSON(modules []moduleInfo, statusMap map[string]RepoStatus, cfg
 		_ = enc.Encode(out)
 	}
 
+	return hasAnyArchived
+}
+
+// runRecursiveSARIF outputs one SARIF document covering all go.mod files,
+// each finding anchored to its own go.mod path.
+func runRecursiveSARIF(modules []moduleInfo, statusMap map[string]RepoStatus, cfg *Config) bool {
+	hasAnyArchived := false
+	inputs := make([]SARIFInput, 0, len(modules))
+
+	for _, mi := range modules {
+		results := applyStatus(mi.githubModules, statusMap)
+
+		il := BuildIgnoreList(filepath.Dir(mi.gomodPath), cfg.IgnoreFile, cfg.IgnoreInline)
+		if il.Len() > 0 {
+			results, _ = il.FilterResults(results)
+		}
+
+		if len(getArchivedPaths(results)) > 0 {
+			hasAnyArchived = true
+		}
+
+		inputs = append(inputs, SARIFInput{
+			GomodURI:   filepath.ToSlash(mi.relPath),
+			Results:    results,
+			Deprecated: getDeprecatedModules(mi.allModules, cfg.DirectOnly, cfg.Deprecated),
+		})
+	}
+
+	PrintSARIF(inputs)
 	return hasAnyArchived
 }
 

--- a/recursive.go
+++ b/recursive.go
@@ -171,6 +171,21 @@ func runRecursive(rootDir string, cfg *Config) int {
 
 	if len(allGitHub) == 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "No GitHub modules found across %d go.mod files.\n", len(modules))
+		if cfg.OutputFormat == "sarif" {
+			cwd, _ := os.Getwd()
+			inputs := make([]SARIFInput, 0, len(modules))
+			for _, mi := range modules {
+				uri := mi.gomodPath
+				if rel, relErr := filepath.Rel(cwd, mi.gomodPath); relErr == nil {
+					uri = rel
+				}
+				inputs = append(inputs, SARIFInput{
+					GomodURI:   filepath.ToSlash(uri),
+					Deprecated: getDeprecatedModules(mi.allModules, cfg.DirectOnly, cfg.Deprecated),
+				})
+			}
+			PrintSARIF(inputs)
+		}
 		return 0
 	}
 

--- a/sarif.go
+++ b/sarif.go
@@ -158,37 +158,116 @@ func deprecatedMessage(m Module) string {
 	return b.String()
 }
 
+// sarifAgg accumulates every occurrence of one (rule, module path) pair
+// across all scanned go.mod files, so buildSARIF can emit a single result
+// with multiple locations instead of one result per occurrence.
+type sarifAgg struct {
+	ruleID       string
+	level        string
+	isDeprecated bool
+	firstRS      RepoStatus // archived: repo data (dates) from the first occurrence
+	firstMod     Module     // deprecated: module data from the first occurrence
+	versions     map[string]bool
+	locations    []string
+	locSeen      map[string]bool
+}
+
+func (a *sarifAgg) addLocation(uri string) {
+	if a.locSeen == nil {
+		a.locSeen = map[string]bool{}
+	}
+	if !a.locSeen[uri] {
+		a.locSeen[uri] = true
+		a.locations = append(a.locations, uri)
+	}
+}
+
+// message builds this aggregate's human-readable message. When the module
+// occurred at more than one version across go.mod files, the version is
+// omitted rather than picking one arbitrarily.
+func (a *sarifAgg) message() string {
+	multiVersion := len(a.versions) > 1
+	if a.isDeprecated {
+		m := a.firstMod
+		if multiVersion {
+			m.Version = ""
+		}
+		return deprecatedMessage(m)
+	}
+	rs := a.firstRS
+	if multiVersion {
+		rs.Module.Version = ""
+	}
+	return archivedMessage(rs)
+}
+
+func (a *sarifAgg) modulePath() string {
+	if a.isDeprecated {
+		return a.firstMod.Path
+	}
+	return a.firstRS.Module.Path
+}
+
+func (a *sarifAgg) fingerprintSuffix() string {
+	if a.isDeprecated {
+		return ":deprecated"
+	}
+	return ":archived"
+}
+
 // buildSARIF assembles one SARIF run from per-go.mod inputs. Results is
-// always non-nil so it serializes as [] rather than null.
+// always non-nil so it serializes as [] rather than null. Occurrences of
+// the same module (by rule + module path) across multiple go.mod files are
+// merged into a single result with one location per distinct go.mod, so
+// partialFingerprints stay unique per result.
 func buildSARIF(inputs []SARIFInput) sarifLog {
-	results := []sarifResult{}
+	var order []string
+	aggs := map[string]*sarifAgg{}
+
 	for _, in := range inputs {
-		loc := sarifGomodLocation(in.GomodURI)
 		for _, rs := range in.Results {
 			if !rs.IsArchived {
 				continue
 			}
-			results = append(results, sarifResult{
-				RuleID:    ruleArchived,
-				Level:     "warning",
-				Message:   sarifText{Text: archivedMessage(rs)},
-				Locations: loc,
-				PartialFingerprints: map[string]string{
-					"modrotFinding/v1": rs.Module.Path + ":archived",
-				},
-			})
+			key := ruleArchived + "|" + rs.Module.Path
+			a, ok := aggs[key]
+			if !ok {
+				a = &sarifAgg{ruleID: ruleArchived, level: "warning", firstRS: rs, versions: map[string]bool{}}
+				aggs[key] = a
+				order = append(order, key)
+			}
+			a.versions[rs.Module.Version] = true
+			a.addLocation(in.GomodURI)
 		}
 		for _, m := range in.Deprecated {
-			results = append(results, sarifResult{
-				RuleID:    ruleDeprecated,
-				Level:     "note",
-				Message:   sarifText{Text: deprecatedMessage(m)},
-				Locations: loc,
-				PartialFingerprints: map[string]string{
-					"modrotFinding/v1": m.Path + ":deprecated",
-				},
-			})
+			key := ruleDeprecated + "|" + m.Path
+			a, ok := aggs[key]
+			if !ok {
+				a = &sarifAgg{ruleID: ruleDeprecated, level: "note", isDeprecated: true, firstMod: m, versions: map[string]bool{}}
+				aggs[key] = a
+				order = append(order, key)
+			}
+			a.versions[m.Version] = true
+			a.addLocation(in.GomodURI)
 		}
+	}
+
+	results := []sarifResult{}
+	for _, key := range order {
+		a := aggs[key]
+		locs := make([]sarifLocation, 0, len(a.locations))
+		for _, uri := range a.locations {
+			locs = append(locs, sarifGomodLocation(uri)[0])
+		}
+		results = append(results, sarifResult{
+			RuleID:    a.ruleID,
+			Level:     a.level,
+			Message:   sarifText{Text: a.message()},
+			Locations: locs,
+			PartialFingerprints: map[string]string{
+				"modrotFinding/v1": a.modulePath() + a.fingerprintSuffix(),
+			},
+		})
 	}
 
 	return sarifLog{

--- a/sarif.go
+++ b/sarif.go
@@ -142,6 +142,22 @@ func archivedMessage(rs RepoStatus) string {
 	return b.String()
 }
 
+// deprecatedMessage builds the human-readable message for a deprecated finding.
+func deprecatedMessage(m Module) string {
+	var b strings.Builder
+	b.WriteString(m.Path)
+	if m.Version != "" {
+		b.WriteString("@")
+		b.WriteString(m.Version)
+	}
+	b.WriteString(" is deprecated")
+	if m.Deprecated != "" {
+		b.WriteString(": ")
+		b.WriteString(m.Deprecated)
+	}
+	return b.String()
+}
+
 // buildSARIF assembles one SARIF run from per-go.mod inputs. Results is
 // always non-nil so it serializes as [] rather than null.
 func buildSARIF(inputs []SARIFInput) sarifLog {
@@ -159,6 +175,17 @@ func buildSARIF(inputs []SARIFInput) sarifLog {
 				Locations: loc,
 				PartialFingerprints: map[string]string{
 					"modrotFinding/v1": rs.Module.Path + ":archived",
+				},
+			})
+		}
+		for _, m := range in.Deprecated {
+			results = append(results, sarifResult{
+				RuleID:    ruleDeprecated,
+				Level:     "note",
+				Message:   sarifText{Text: deprecatedMessage(m)},
+				Locations: loc,
+				PartialFingerprints: map[string]string{
+					"modrotFinding/v1": m.Path + ":deprecated",
 				},
 			})
 		}

--- a/sarif.go
+++ b/sarif.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SARIF 2.1.0 output for GitHub code-scanning (issue #17, v1 file-level
+// anchoring). Structs are a hand-rolled subset of the spec — only the
+// fields code-scanning needs.
+
+const sarifSchemaURI = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+
+const (
+	ruleArchived   = "archived-dependency"
+	ruleDeprecated = "deprecated-dependency"
+)
+
+// SARIFInput groups the findings for one scanned go.mod file.
+// GomodURI must be repo-relative with forward slashes.
+type SARIFInput struct {
+	GomodURI   string
+	Results    []RepoStatus
+	Deprecated []Module
+}
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	Version        string      `json:"version"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	ShortDescription     sarifText         `json:"shortDescription"`
+	HelpURI              string            `json:"helpUri"`
+	DefaultConfiguration sarifLevel        `json:"defaultConfiguration"`
+	Properties           map[string]string `json:"properties"`
+}
+
+type sarifText struct {
+	Text string `json:"text"`
+}
+
+type sarifLevel struct {
+	Level string `json:"level"`
+}
+
+type sarifResult struct {
+	RuleID              string            `json:"ruleId"`
+	Level               string            `json:"level"`
+	Message             sarifText         `json:"message"`
+	Locations           []sarifLocation   `json:"locations"`
+	PartialFingerprints map[string]string `json:"partialFingerprints"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+// sarifRules returns the two rule definitions, always both, in a fixed
+// order (archived first) so output is deterministic.
+func sarifRules() []sarifRule {
+	const repoURL = "https://github.com/norman-abramovitz/modrot"
+	return []sarifRule{
+		{
+			ID:                   ruleArchived,
+			Name:                 "ArchivedDependency",
+			ShortDescription:     sarifText{Text: "Dependency repository is archived on GitHub"},
+			HelpURI:              repoURL + "#readme",
+			DefaultConfiguration: sarifLevel{Level: "warning"},
+			Properties:           map[string]string{"security-severity": "5.5"},
+		},
+		{
+			ID:                   ruleDeprecated,
+			Name:                 "DeprecatedDependency",
+			ShortDescription:     sarifText{Text: "Dependency module is marked deprecated in its go.mod"},
+			HelpURI:              repoURL + "#readme",
+			DefaultConfiguration: sarifLevel{Level: "note"},
+			Properties:           map[string]string{"security-severity": "3.0"},
+		},
+	}
+}
+
+// sarifGomodLocation returns a single path-only location for the go.mod file.
+func sarifGomodLocation(uri string) []sarifLocation {
+	return []sarifLocation{{
+		PhysicalLocation: sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{URI: uri},
+		},
+	}}
+}
+
+// archivedMessage builds the human-readable message for an archived finding.
+func archivedMessage(rs RepoStatus) string {
+	var b strings.Builder
+	b.WriteString(rs.Module.Path)
+	if rs.Module.Version != "" {
+		b.WriteString("@")
+		b.WriteString(rs.Module.Version)
+	}
+	b.WriteString(" is archived on GitHub")
+	var details []string
+	if !rs.ArchivedAt.IsZero() {
+		details = append(details, "archived "+rs.ArchivedAt.Format("2006-01-02"))
+	}
+	if !rs.PushedAt.IsZero() {
+		details = append(details, "last pushed "+rs.PushedAt.Format("2006-01-02"))
+	}
+	if len(details) > 0 {
+		b.WriteString(" (")
+		b.WriteString(strings.Join(details, ", "))
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// buildSARIF assembles one SARIF run from per-go.mod inputs. Results is
+// always non-nil so it serializes as [] rather than null.
+func buildSARIF(inputs []SARIFInput) sarifLog {
+	results := []sarifResult{}
+	for _, in := range inputs {
+		loc := sarifGomodLocation(in.GomodURI)
+		for _, rs := range in.Results {
+			if !rs.IsArchived {
+				continue
+			}
+			results = append(results, sarifResult{
+				RuleID:    ruleArchived,
+				Level:     "warning",
+				Message:   sarifText{Text: archivedMessage(rs)},
+				Locations: loc,
+				PartialFingerprints: map[string]string{
+					"modrotFinding/v1": rs.Module.Path + ":archived",
+				},
+			})
+		}
+	}
+
+	return sarifLog{
+		Schema:  sarifSchemaURI,
+		Version: "2.1.0",
+		Runs: []sarifRun{{
+			Tool: sarifTool{Driver: sarifDriver{
+				Name:           "modrot",
+				Version:        version,
+				InformationURI: "https://github.com/norman-abramovitz/modrot",
+				Rules:          sarifRules(),
+			}},
+			Results: results,
+		}},
+	}
+}
+
+// PrintSARIF writes the SARIF log for the given inputs to stdout.
+func PrintSARIF(inputs []SARIFInput) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(buildSARIF(inputs)); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error encoding SARIF: %v\n", err)
+	}
+}

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -150,3 +150,34 @@ func TestPrintSARIF_ValidDocument(t *testing.T) {
 		t.Fatalf("runs = %d", len(runs))
 	}
 }
+
+func TestBuildSARIF_MultipleGoMods(t *testing.T) {
+	inputs := []SARIFInput{
+		{
+			GomodURI: "svc-a/go.mod",
+			Results: []RepoStatus{{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar"},
+				IsArchived: true,
+			}},
+		},
+		{
+			GomodURI: "svc-b/go.mod",
+			Results: []RepoStatus{{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.1.0", Owner: "foo", Repo: "bar"},
+				IsArchived: true,
+			}},
+		},
+	}
+
+	run := buildSARIF(inputs).Runs[0]
+	if len(run.Results) != 2 {
+		t.Fatalf("results = %d, want 2 (one per go.mod)", len(run.Results))
+	}
+	uris := []string{
+		run.Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI,
+		run.Results[1].Locations[0].PhysicalLocation.ArtifactLocation.URI,
+	}
+	if uris[0] != "svc-a/go.mod" || uris[1] != "svc-b/go.mod" {
+		t.Errorf("uris = %v", uris)
+	}
+}

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -197,14 +197,55 @@ func TestBuildSARIF_MultipleGoMods(t *testing.T) {
 	}
 
 	run := buildSARIF(inputs).Runs[0]
-	if len(run.Results) != 2 {
-		t.Fatalf("results = %d, want 2 (one per go.mod)", len(run.Results))
+	if len(run.Results) != 1 {
+		t.Fatalf("results = %d, want 1 (deduped, one per rule+module)", len(run.Results))
+	}
+	r := run.Results[0]
+	if len(r.Locations) != 2 {
+		t.Fatalf("locations = %d, want 2", len(r.Locations))
 	}
 	uris := []string{
-		run.Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI,
-		run.Results[1].Locations[0].PhysicalLocation.ArtifactLocation.URI,
+		r.Locations[0].PhysicalLocation.ArtifactLocation.URI,
+		r.Locations[1].PhysicalLocation.ArtifactLocation.URI,
 	}
 	if uris[0] != "svc-a/go.mod" || uris[1] != "svc-b/go.mod" {
 		t.Errorf("uris = %v", uris)
+	}
+	if strings.Contains(r.Message.Text, "@v1.0.0") || strings.Contains(r.Message.Text, "@v1.1.0") || strings.Contains(r.Message.Text, "@") {
+		t.Errorf("message should omit version when occurrences differ, got %q", r.Message.Text)
+	}
+	if r.PartialFingerprints["modrotFinding/v1"] != "github.com/foo/bar:archived" {
+		t.Errorf("fingerprint = %q", r.PartialFingerprints["modrotFinding/v1"])
+	}
+}
+
+func TestBuildSARIF_MultipleGoMods_SameVersion(t *testing.T) {
+	inputs := []SARIFInput{
+		{
+			GomodURI: "svc-a/go.mod",
+			Results: []RepoStatus{{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar"},
+				IsArchived: true,
+			}},
+		},
+		{
+			GomodURI: "svc-b/go.mod",
+			Results: []RepoStatus{{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar"},
+				IsArchived: true,
+			}},
+		},
+	}
+
+	run := buildSARIF(inputs).Runs[0]
+	if len(run.Results) != 1 {
+		t.Fatalf("results = %d, want 1 (deduped, one per rule+module)", len(run.Results))
+	}
+	r := run.Results[0]
+	if len(r.Locations) != 2 {
+		t.Fatalf("locations = %d, want 2", len(r.Locations))
+	}
+	if !strings.Contains(r.Message.Text, "@v1.0.0") {
+		t.Errorf("message should keep version when all occurrences agree, got %q", r.Message.Text)
 	}
 }

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -249,3 +249,46 @@ func TestBuildSARIF_MultipleGoMods_SameVersion(t *testing.T) {
 		t.Errorf("message should keep version when all occurrences agree, got %q", r.Message.Text)
 	}
 }
+
+func TestDeprecatedMessage_EmptyVersion(t *testing.T) {
+	got := deprecatedMessage(Module{Path: "github.com/old/lib", Deprecated: "use new/lib"})
+	want := "github.com/old/lib is deprecated: use new/lib"
+	if got != want {
+		t.Errorf("message = %q, want %q", got, want)
+	}
+}
+
+func TestDeprecatedMessage_EmptyDeprecationText(t *testing.T) {
+	got := deprecatedMessage(Module{Path: "github.com/old/lib", Version: "v1.0.0"})
+	want := "github.com/old/lib@v1.0.0 is deprecated"
+	if got != want {
+		t.Errorf("message = %q, want %q", got, want)
+	}
+}
+
+// TestBuildSARIF_ArchivedAndDeprecated pins that a module which is both
+// archived and deprecated in the same input produces TWO results — one per
+// rule — so a future dedup change doesn't accidentally merge across rules.
+func TestBuildSARIF_ArchivedAndDeprecated(t *testing.T) {
+	inputs := []SARIFInput{{
+		GomodURI: "go.mod",
+		Results: []RepoStatus{{
+			Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar"},
+			IsArchived: true,
+		}},
+		Deprecated: []Module{
+			{Path: "github.com/foo/bar", Version: "v1.0.0", Deprecated: "use something else"},
+		},
+	}}
+
+	run := buildSARIF(inputs).Runs[0]
+	if len(run.Results) != 2 {
+		t.Fatalf("results = %d, want 2 (one archived, one deprecated)", len(run.Results))
+	}
+	if run.Results[0].RuleID != ruleArchived {
+		t.Errorf("results[0].RuleID = %q, want %q", run.Results[0].RuleID, ruleArchived)
+	}
+	if run.Results[1].RuleID != ruleDeprecated {
+		t.Errorf("results[1].RuleID = %q, want %q", run.Results[1].RuleID, ruleDeprecated)
+	}
+}

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -148,6 +149,32 @@ func TestPrintSARIF_ValidDocument(t *testing.T) {
 	runs := doc["runs"].([]any)
 	if len(runs) != 1 {
 		t.Fatalf("runs = %d", len(runs))
+	}
+}
+
+func TestPrintSARIF_EmptyInput(t *testing.T) {
+	output := captureStdout(t, func() {
+		PrintSARIF([]SARIFInput{{GomodURI: "go.mod"}})
+	})
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(output), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, output)
+	}
+	runs := doc["runs"].([]any)
+	if len(runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(runs))
+	}
+	run := runs[0].(map[string]any)
+	results, ok := run["results"].([]any)
+	if !ok {
+		t.Fatalf("results field missing or not an array: %+v", run["results"])
+	}
+	if len(results) != 0 {
+		t.Errorf("results = %d, want 0", len(results))
+	}
+	if !strings.Contains(output, `"results": []`) {
+		t.Errorf("output does not contain literal %q\noutput: %s", `"results": []`, output)
 	}
 }
 

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -118,5 +119,34 @@ func TestBuildSARIF_Deprecated(t *testing.T) {
 	}
 	if r.PartialFingerprints["modrotFinding/v1"] != "github.com/old/lib:deprecated" {
 		t.Errorf("fingerprint = %q", r.PartialFingerprints["modrotFinding/v1"])
+	}
+}
+
+func TestPrintSARIF_ValidDocument(t *testing.T) {
+	inputs := []SARIFInput{{
+		GomodURI: "go.mod",
+		Results: []RepoStatus{{
+			Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar"},
+			IsArchived: true,
+		}},
+	}}
+
+	output := captureStdout(t, func() {
+		PrintSARIF(inputs)
+	})
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(output), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, output)
+	}
+	if doc["version"] != "2.1.0" {
+		t.Errorf("version = %v", doc["version"])
+	}
+	if doc["$schema"] != sarifSchemaURI {
+		t.Errorf("$schema = %v", doc["$schema"])
+	}
+	runs := doc["runs"].([]any)
+	if len(runs) != 1 {
+		t.Fatalf("runs = %d", len(runs))
 	}
 }

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildSARIF_ArchivedResult(t *testing.T) {
+	inputs := []SARIFInput{{
+		GomodURI: "go.mod",
+		Results: []RepoStatus{
+			{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Direct: true, Owner: "foo", Repo: "bar"},
+				IsArchived: true,
+				ArchivedAt: time.Date(2024, 7, 22, 0, 0, 0, 0, time.UTC),
+				PushedAt:   time.Date(2021, 5, 5, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				Module:     Module{Path: "github.com/baz/qux", Version: "v2.0.0", Direct: false, Owner: "baz", Repo: "qux"},
+				IsArchived: false,
+				PushedAt:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}}
+
+	log := buildSARIF(inputs)
+
+	if log.Version != "2.1.0" {
+		t.Errorf("version = %q, want 2.1.0", log.Version)
+	}
+	if len(log.Runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(log.Runs))
+	}
+	run := log.Runs[0]
+	if run.Tool.Driver.Name != "modrot" {
+		t.Errorf("driver name = %q, want modrot", run.Tool.Driver.Name)
+	}
+	if len(run.Tool.Driver.Rules) != 2 {
+		t.Fatalf("rules = %d, want 2", len(run.Tool.Driver.Rules))
+	}
+	if run.Tool.Driver.Rules[0].ID != "archived-dependency" || run.Tool.Driver.Rules[1].ID != "deprecated-dependency" {
+		t.Errorf("rule ids = %q, %q", run.Tool.Driver.Rules[0].ID, run.Tool.Driver.Rules[1].ID)
+	}
+	if run.Tool.Driver.Rules[0].Properties["security-severity"] != "5.5" {
+		t.Errorf("archived security-severity = %q, want 5.5", run.Tool.Driver.Rules[0].Properties["security-severity"])
+	}
+
+	if len(run.Results) != 1 {
+		t.Fatalf("results = %d, want 1 (only the archived module)", len(run.Results))
+	}
+	r := run.Results[0]
+	if r.RuleID != "archived-dependency" {
+		t.Errorf("ruleId = %q", r.RuleID)
+	}
+	if r.Level != "warning" {
+		t.Errorf("level = %q, want warning", r.Level)
+	}
+	if r.Message.Text != "github.com/foo/bar@v1.0.0 is archived on GitHub (archived 2024-07-22, last pushed 2021-05-05)" {
+		t.Errorf("message = %q", r.Message.Text)
+	}
+	if len(r.Locations) != 1 || r.Locations[0].PhysicalLocation.ArtifactLocation.URI != "go.mod" {
+		t.Errorf("locations = %+v, want one uri go.mod", r.Locations)
+	}
+	if r.PartialFingerprints["modrotFinding/v1"] != "github.com/foo/bar:archived" {
+		t.Errorf("fingerprint = %q", r.PartialFingerprints["modrotFinding/v1"])
+	}
+}
+
+func TestBuildSARIF_NoFindings(t *testing.T) {
+	log := buildSARIF([]SARIFInput{{GomodURI: "go.mod"}})
+	if log.Runs[0].Results == nil {
+		t.Error("results must be non-nil (serializes as [] not null)")
+	}
+	if len(log.Runs[0].Results) != 0 {
+		t.Errorf("results = %d, want 0", len(log.Runs[0].Results))
+	}
+}
+
+func TestBuildSARIF_ArchivedNoDates(t *testing.T) {
+	inputs := []SARIFInput{{
+		GomodURI: "go.mod",
+		Results: []RepoStatus{{
+			Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar"},
+			IsArchived: true,
+		}},
+	}}
+	r := buildSARIF(inputs).Runs[0].Results[0]
+	if r.Message.Text != "github.com/foo/bar@v1.0.0 is archived on GitHub" {
+		t.Errorf("message = %q", r.Message.Text)
+	}
+}

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -89,3 +89,34 @@ func TestBuildSARIF_ArchivedNoDates(t *testing.T) {
 		t.Errorf("message = %q", r.Message.Text)
 	}
 }
+
+func TestBuildSARIF_Deprecated(t *testing.T) {
+	inputs := []SARIFInput{{
+		GomodURI: "go.mod",
+		Deprecated: []Module{
+			{Path: "github.com/old/lib", Version: "v1.2.0", Deprecated: "use github.com/new/lib instead"},
+		},
+	}}
+
+	run := buildSARIF(inputs).Runs[0]
+	if len(run.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(run.Results))
+	}
+	r := run.Results[0]
+	if r.RuleID != "deprecated-dependency" {
+		t.Errorf("ruleId = %q", r.RuleID)
+	}
+	if r.Level != "note" {
+		t.Errorf("level = %q, want note", r.Level)
+	}
+	want := "github.com/old/lib@v1.2.0 is deprecated: use github.com/new/lib instead"
+	if r.Message.Text != want {
+		t.Errorf("message = %q, want %q", r.Message.Text, want)
+	}
+	if r.Locations[0].PhysicalLocation.ArtifactLocation.URI != "go.mod" {
+		t.Errorf("uri = %q", r.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+	}
+	if r.PartialFingerprints["modrotFinding/v1"] != "github.com/old/lib:deprecated" {
+		t.Errorf("fingerprint = %q", r.PartialFingerprints["modrotFinding/v1"])
+	}
+}


### PR DESCRIPTION
Closes #17.

Adds `--format sarif` (and `--sarif` alias) emitting SARIF 2.1.0 on stdout for GitHub code-scanning: archived dependencies as `archived-dependency` (warning, security-severity 5.5), deprecated as `deprecated-dependency` (note, 3.0), anchored to the scanned go.mod with repo-relative URIs. Hand-rolled struct subset, no new dependencies.

## Design notes

- **One result per (rule, module), multiple locations.** A module required by several go.mod files (recursive mode) produces a single result whose `locations[]` lists every go.mod occurrence — file-level version of the #18 design. `partialFingerprints` (`<module>:<status>`) are therefore unique per result. Messages keep `@version` only when all occurrences agree.
- **A valid document is always emitted**, including `"results": []` when a scan finds nothing (or has no GitHub-hosted deps), so the upload step never receives an empty file.
- **Recursive mode** emits one document with cwd-relative per-go.mod URIs; run from the repository root (`modrot --recursive --sarif .`).
- SARIF is flat-only (`--tree` is ignored); stale/age/stats sections are not represented; exit-code semantics unchanged (1 when archived deps found — the README's Action snippet uses `|| true` so upload still runs).

## Testing

- Unit tests for builder, printer, dedup ordering, version-agreement branches, message edge cases, and the `[]`-not-`null` serialization.
- End-to-end against openbao: single-module (17 archived + 2 deprecated) and recursive (9 go.mod files; e.g. one module merged from 9 occurrences into 1 result with 9 locations), plus a zero-GitHub-deps module (valid empty document, exit 0). `make verify` green.

## Code-scanning validation (done)

Validated via the SARIF upload API against this branch: a findings document (2 archived + 1 deprecated) processed with zero errors and produced alerts with the intended mapping (warning/medium, note/low, messages verbatim, anchored at go.mod), and an empty `"results": []` document was accepted cleanly — its analysis also correctly superseded and closed the prior alerts, confirming the open-to-fixed lifecycle. Test analyses were deleted afterwards. Remaining watch items for the GitHub Action work: the 10-locations-per-result cap (a real monorepo scan already produced 9), and whether `continue-on-error: true` beats `|| true` (which also swallows exit 2).

## Follow-ups (not in this PR)

- Per-import-site `file:line` locations with `--files` (#17's follow-up section)
- Require-line regions + quickfix targets — #18, whose scope this PR narrows (multi-location results now exist; #18 becomes line anchoring through `ParseGoMod`)
