### PR TITLE
document homebrew tap trust requirement for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Archived dependencies no longer receive security patches, bug fixes, or compatib
 ### Homebrew
 
 ```bash
+brew trust norman-abramovitz/tap
 brew install norman-abramovitz/tap/modrot
 ```
+
+Homebrew 6.0+ requires third-party taps to be trusted before their code runs, so `brew trust` must come first. On older Homebrew the `brew trust` line is unnecessary (and unrecognized) — skip it and run `brew install` directly.
 
 ### Go
 


### PR DESCRIPTION
Homebrew 6.0.0 (2026-06-11) enforces third-party tap trust by default. Auto-tapping of untrusted taps is stopped, so `brew install norman-abramovitz/tap/modrot` now needs `brew trust norman-abramovitz/tap` first. Adds that step to the README install section with a note that older Homebrew can skip it.