### PR TITLE
Anchor findings to go.mod require lines (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ $ modrot --sarif --deprecated > modrot.sarif
     sarif_file: modrot.sarif
 ```
 
-The `|| true` keeps the workflow running when modrot exits 1 on archived findings, so the upload step still runs. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the scanned `go.mod` file (with `--recursive`, to each go.mod in the tree). SARIF paths are always relative to the current working directory, so run modrot from the repository root — e.g. `modrot --recursive --sarif . > modrot.sarif` — so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
+The `|| true` keeps the workflow running when modrot exits 1 on archived findings, so the upload step still runs. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the exact `require` line in the scanned `go.mod` file (with `--recursive`, to each go.mod in the tree — a module required from several go.mod files becomes one result with a location per require site). SARIF paths are always relative to the current working directory, so run modrot from the repository root — e.g. `modrot --recursive --sarif . > modrot.sarif` — so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
 
 **Sorting** — sort archived dependencies by field and direction. Append `:asc` or `:desc` to control order. Each field has a natural default:
 

--- a/README.md
+++ b/README.md
@@ -350,12 +350,14 @@ modrot --json | jq -r '.archived[].module'
 modrot --json | jq '[.archived[] | select(.direct)] | length'
 ```
 
-**Editor quickfix** — navigate directly to files importing archived modules:
+**Editor quickfix** — navigate directly to each archived module's `require` line in `go.mod`, then to the source files importing it:
 
 ```
 $ modrot --quickfix
+go.mod:94:github.com/mitchellh/copystructure
 audit/hashstructure.go:14:github.com/mitchellh/copystructure
 sdk/logical/request.go:14:github.com/mitchellh/copystructure
+go.mod:95:github.com/mitchellh/reflectwalk
 audit/hashstructure.go:15:github.com/mitchellh/reflectwalk
 ```
 

--- a/main.go
+++ b/main.go
@@ -477,7 +477,7 @@ func outputFlat(cfg *Config, gomodRel string, results []RepoStatus, nonGitHubMod
 	switch cfg.OutputFormat {
 	case "quickfix":
 		if fileMatches != nil {
-			PrintFilesPlain(results, fileMatches)
+			PrintFilesPlain(gomodRel, results, fileMatches)
 		}
 	case "sarif":
 		PrintSARIF([]SARIFInput{{GomodURI: gomodRel, Results: results, Deprecated: deprecatedModules}})

--- a/modparse.go
+++ b/modparse.go
@@ -14,6 +14,7 @@ type Module struct {
 	Path          string // full module path, e.g. "github.com/foo/bar/v2"
 	Version       string
 	Direct        bool
+	Line          int       // 1-based require line in the source go.mod (0 if unknown)
 	Owner         string    // GitHub owner (empty if non-GitHub)
 	Repo          string    // GitHub repo name (empty if non-GitHub)
 	Deprecated    string    // deprecation message from go.mod, empty if not deprecated
@@ -41,6 +42,9 @@ func ParseGoMod(path string) ([]Module, error) {
 			Path:    req.Mod.Path,
 			Version: req.Mod.Version,
 			Direct:  !req.Indirect,
+		}
+		if req.Syntax != nil {
+			m.Line = req.Syntax.Start.Line
 		}
 		m.Owner, m.Repo = extractGitHub(req.Mod.Path)
 		modules = append(modules, m)

--- a/modparse_test.go
+++ b/modparse_test.go
@@ -136,6 +136,42 @@ require (
 	}
 }
 
+func TestParseGoModCapturesRequireLine(t *testing.T) {
+	gomod := `module example.com/myapp
+
+go 1.21
+
+require (
+	github.com/foo/bar v1.2.3
+	github.com/baz/qux v0.1.0 // indirect
+	golang.org/x/text v0.14.0
+)
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(path, []byte(gomod), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	modules, err := ParseGoMod(path)
+	if err != nil {
+		t.Fatalf("ParseGoMod() error: %v", err)
+	}
+
+	// Each require sits on its own line inside the block: foo/bar on line 6,
+	// baz/qux on line 7, x/text on line 8.
+	wantLines := map[string]int{
+		"github.com/foo/bar": 6,
+		"github.com/baz/qux": 7,
+		"golang.org/x/text":  8,
+	}
+	for _, m := range modules {
+		if got := wantLines[m.Path]; m.Line != got {
+			t.Errorf("%s Line = %d, want %d", m.Path, m.Line, got)
+		}
+	}
+}
+
 func TestParseGoMod_FileNotFound(t *testing.T) {
 	_, err := ParseGoMod("/nonexistent/go.mod")
 	if err == nil {

--- a/output.go
+++ b/output.go
@@ -621,16 +621,23 @@ func PrintFiles(results []RepoStatus, fileMatches map[string][]FileMatch) {
 
 // PrintFilesPlain outputs quickfix-format lines: file:line:module_path
 // This format is compatible with vim's quickfix list and similar editor integrations.
-func PrintFilesPlain(results []RepoStatus, fileMatches map[string][]FileMatch) {
+// For each archived module it emits the go.mod require site first (when the
+// require line is known), then every source-file import site.
+func PrintFilesPlain(gomodPath string, results []RepoStatus, fileMatches map[string][]FileMatch) {
+	lineByPath := make(map[string]int)
 	var archivedPaths []string
 	for _, r := range results {
 		if r.IsArchived {
 			archivedPaths = append(archivedPaths, r.Module.Path)
+			lineByPath[r.Module.Path] = r.Module.Line
 		}
 	}
 	sort.Strings(archivedPaths)
 
 	for _, modPath := range archivedPaths {
+		if line := lineByPath[modPath]; line > 0 {
+			_, _ = fmt.Fprintf(os.Stdout, "%s:%d:%s\n", gomodPath, line, modPath)
+		}
 		for _, m := range fileMatches[modPath] {
 			_, _ = fmt.Fprintf(os.Stdout, "%s:%d:%s\n", m.File, m.Line, modPath)
 		}

--- a/output_test.go
+++ b/output_test.go
@@ -192,6 +192,52 @@ func TestFormatArchivedLine_NoDates(t *testing.T) {
 	}
 }
 
+// TestPrintFilesPlain_IncludesGomodRequireSite pins issue #18: quickfix output
+// emits the go.mod require site (gomod:line:module) for each archived module,
+// ahead of any source-file import sites.
+func TestPrintFilesPlain_IncludesGomodRequireSite(t *testing.T) {
+	results := []RepoStatus{{
+		Module:     Module{Path: "github.com/foo/bar", Owner: "foo", Repo: "bar", Line: 7},
+		IsArchived: true,
+	}}
+	fileMatches := map[string][]FileMatch{
+		"github.com/foo/bar": {{File: "internal/app.go", Line: 12}},
+	}
+
+	out := captureStdout(t, func() {
+		PrintFilesPlain("go.mod", results, fileMatches)
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	want := []string{
+		"go.mod:7:github.com/foo/bar",
+		"internal/app.go:12:github.com/foo/bar",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d lines %q, want %d", len(lines), lines, len(want))
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, lines[i], want[i])
+		}
+	}
+}
+
+// TestPrintFilesPlain_SkipsGomodSiteWhenLineUnknown pins that a zero require
+// line does not emit a bogus gomod:0: quickfix target.
+func TestPrintFilesPlain_SkipsGomodSiteWhenLineUnknown(t *testing.T) {
+	results := []RepoStatus{{
+		Module:     Module{Path: "github.com/foo/bar", Owner: "foo", Repo: "bar"},
+		IsArchived: true,
+	}}
+	out := captureStdout(t, func() {
+		PrintFilesPlain("go.mod", results, map[string][]FileMatch{})
+	})
+	if strings.Contains(out, "go.mod:0:") {
+		t.Errorf("should not emit bogus line-0 go.mod site, got %q", out)
+	}
+}
+
 // captureStdout captures stdout output during fn execution.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
@@ -1477,7 +1523,7 @@ func TestPrintFilesPlain(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		PrintFilesPlain(results, fileMatches)
+		PrintFilesPlain("go.mod", results, fileMatches)
 	})
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")

--- a/recursive.go
+++ b/recursive.go
@@ -252,7 +252,7 @@ func runRecursiveQuickfix(modules []moduleInfo, statusMap map[string]RepoStatus,
 				_, _ = fmt.Fprintf(os.Stderr, "Warning: could not scan imports for %s: %v\n", mi.relPath, err)
 				continue
 			}
-			PrintFilesPlain(results, fm)
+			PrintFilesPlain(filepath.ToSlash(mi.relPath), results, fm)
 		}
 	}
 

--- a/sarif.go
+++ b/sarif.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-// SARIF 2.1.0 output for GitHub code-scanning (issue #17, v1 file-level
-// anchoring). Structs are a hand-rolled subset of the spec — only the
-// fields code-scanning needs.
+// SARIF 2.1.0 output for GitHub code-scanning (issue #17, anchored to the
+// go.mod require line per issue #18). Structs are a hand-rolled subset of the
+// spec — only the fields code-scanning needs.
 
 const sarifSchemaURI = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
 
@@ -79,10 +79,17 @@ type sarifLocation struct {
 
 type sarifPhysicalLocation struct {
 	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
 }
 
 type sarifArtifactLocation struct {
 	URI string `json:"uri"`
+}
+
+// sarifRegion anchors a location to a specific line. Emitted only when the
+// require line is known; a nil region keeps the location file-level.
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
 }
 
 // sarifRules returns the two rule definitions, always both, in a fixed
@@ -109,13 +116,19 @@ func sarifRules() []sarifRule {
 	}
 }
 
-// sarifGomodLocation returns a single path-only location for the go.mod file.
-func sarifGomodLocation(uri string) []sarifLocation {
-	return []sarifLocation{{
+// sarifGomodLocation returns a location for the go.mod file, anchored to the
+// require line when known (line > 0) and file-level otherwise.
+func sarifGomodLocation(uri string, line int) sarifLocation {
+	var region *sarifRegion
+	if line > 0 {
+		region = &sarifRegion{StartLine: line}
+	}
+	return sarifLocation{
 		PhysicalLocation: sarifPhysicalLocation{
 			ArtifactLocation: sarifArtifactLocation{URI: uri},
+			Region:           region,
 		},
-	}}
+	}
 }
 
 // archivedMessage builds the human-readable message for an archived finding.
@@ -168,17 +181,25 @@ type sarifAgg struct {
 	firstRS      RepoStatus // archived: repo data (dates) from the first occurrence
 	firstMod     Module     // deprecated: module data from the first occurrence
 	versions     map[string]bool
-	locations    []string
+	locations    []sarifOccurrence
 	locSeen      map[string]bool
 }
 
-func (a *sarifAgg) addLocation(uri string) {
+// sarifOccurrence is one {go.mod file, require line} site where a module was
+// found. A module can occur across multiple go.mod files, so an aggregate
+// keeps a list of these.
+type sarifOccurrence struct {
+	uri  string
+	line int
+}
+
+func (a *sarifAgg) addLocation(uri string, line int) {
 	if a.locSeen == nil {
 		a.locSeen = map[string]bool{}
 	}
 	if !a.locSeen[uri] {
 		a.locSeen[uri] = true
-		a.locations = append(a.locations, uri)
+		a.locations = append(a.locations, sarifOccurrence{uri: uri, line: line})
 	}
 }
 
@@ -237,7 +258,7 @@ func buildSARIF(inputs []SARIFInput) sarifLog {
 				order = append(order, key)
 			}
 			a.versions[rs.Module.Version] = true
-			a.addLocation(in.GomodURI)
+			a.addLocation(in.GomodURI, rs.Module.Line)
 		}
 		for _, m := range in.Deprecated {
 			key := ruleDeprecated + "|" + m.Path
@@ -248,7 +269,7 @@ func buildSARIF(inputs []SARIFInput) sarifLog {
 				order = append(order, key)
 			}
 			a.versions[m.Version] = true
-			a.addLocation(in.GomodURI)
+			a.addLocation(in.GomodURI, m.Line)
 		}
 	}
 
@@ -256,8 +277,8 @@ func buildSARIF(inputs []SARIFInput) sarifLog {
 	for _, key := range order {
 		a := aggs[key]
 		locs := make([]sarifLocation, 0, len(a.locations))
-		for _, uri := range a.locations {
-			locs = append(locs, sarifGomodLocation(uri)[0])
+		for _, occ := range a.locations {
+			locs = append(locs, sarifGomodLocation(occ.uri, occ.line))
 		}
 		results = append(results, sarifResult{
 			RuleID:    a.ruleID,

--- a/sarif_test.go
+++ b/sarif_test.go
@@ -219,6 +219,65 @@ func TestBuildSARIF_MultipleGoMods(t *testing.T) {
 	}
 }
 
+// TestBuildSARIF_RequireLineRegions is the issue #18 acceptance fixture: a
+// module required from two go.mod files at different require lines produces one
+// result with two locations, each anchored to its own require line via
+// region.startLine.
+func TestBuildSARIF_RequireLineRegions(t *testing.T) {
+	inputs := []SARIFInput{
+		{
+			GomodURI: "svc-a/go.mod",
+			Results: []RepoStatus{{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar", Line: 7},
+				IsArchived: true,
+			}},
+		},
+		{
+			GomodURI: "svc-b/go.mod",
+			Results: []RepoStatus{{
+				Module:     Module{Path: "github.com/foo/bar", Version: "v1.0.0", Owner: "foo", Repo: "bar", Line: 12},
+				IsArchived: true,
+			}},
+		},
+	}
+
+	run := buildSARIF(inputs).Runs[0]
+	if len(run.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(run.Results))
+	}
+	r := run.Results[0]
+	if len(r.Locations) != 2 {
+		t.Fatalf("locations = %d, want 2", len(r.Locations))
+	}
+	byURI := map[string]int{}
+	for _, loc := range r.Locations {
+		byURI[loc.PhysicalLocation.ArtifactLocation.URI] = loc.PhysicalLocation.Region.StartLine
+	}
+	if byURI["svc-a/go.mod"] != 7 {
+		t.Errorf("svc-a startLine = %d, want 7", byURI["svc-a/go.mod"])
+	}
+	if byURI["svc-b/go.mod"] != 12 {
+		t.Errorf("svc-b startLine = %d, want 12", byURI["svc-b/go.mod"])
+	}
+}
+
+// TestBuildSARIF_NoRegionWhenLineUnknown pins that a zero require line omits the
+// region entirely (no bogus startLine 0) so file-level anchoring still works.
+func TestBuildSARIF_NoRegionWhenLineUnknown(t *testing.T) {
+	inputs := []SARIFInput{{
+		GomodURI: "go.mod",
+		Results: []RepoStatus{{
+			Module:     Module{Path: "github.com/foo/bar", Owner: "foo", Repo: "bar"},
+			IsArchived: true,
+		}},
+	}}
+
+	r := buildSARIF(inputs).Runs[0].Results[0]
+	if r.Locations[0].PhysicalLocation.Region != nil {
+		t.Errorf("region = %+v, want nil when line unknown", r.Locations[0].PhysicalLocation.Region)
+	}
+}
+
 func TestBuildSARIF_MultipleGoMods_SameVersion(t *testing.T) {
 	inputs := []SARIFInput{
 		{


### PR DESCRIPTION
Closes #18.

Captures the `require` line in `ParseGoMod` and threads `{go.mod file, line}` occurrences through both SARIF and quickfix output, upgrading anchors from file-level to the exact require line.

## Changes (3 atomic commits)

1. **capture require line in ParseGoMod** — records `req.Syntax.Start.Line` on each `Module` (0 when unknown).
2. **anchor SARIF results to the go.mod require line** — adds `region.startLine` to each SARIF location; the aggregator now keeps `{uri, line}` occurrences, so a module required from several go.mod files yields one result with a line-anchored location per require site. Region omitted when the line is unknown, preserving file-level anchoring.
3. **emit go.mod require sites in quickfix output** — each archived module leads with its `go.mod:line:module` require site before source-file import sites, so every require site is navigable (including indirect deps with no direct import).

## Acceptance criteria (from #18)

- [x] Each deduped package carries a list of `{go.mod file, require line}` occurrences (SARIF aggregator).
- [x] Fixture test with a module required from two go.mod files asserts both occurrences with correct file paths and line numbers (`TestBuildSARIF_RequireLineRegions`).

## Verification

- TDD red-green throughout; `make verify` clean (0 lint, tests pass, trivy/gosec/gitleaks clean).
- End-to-end against a real go.mod: SARIF `region.startLine` values match the actual `require` lines; quickfix emits `go.mod:<line>:<module>` ahead of source import sites.

Docs updated: SARIF and quickfix sections in README.