### PR TITLE
Exit 3 when a scan could not complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ are always called out under **BREAKING** below.
 
 ## [Unreleased]
 
+### Added
+
+- Exit code `3` — scan incomplete. An upstream that could not be reached
+  (network error, 429, 5xx) now changes the exit status instead of only warning
+  on stderr. It takes precedence over `1`: a scan that could not check
+  everything does not know whether the project is clean.
+
+  This closes a real hazard. Under `--sarif` in CI, an unreachable registry
+  produced a short or empty run that still exited `0`, and GitHub treats an
+  uploaded run as the complete current state — so an outage could silently
+  close alerts nobody had fixed. The README's CI recipe is updated to gate the
+  upload on the exit code rather than swallowing it with `|| true`.
+
+### Fixed
+
+- The Go module proxy path could not tell a failed request from "this module
+  has no deprecation comment" — `fetchGoModDeprecation` returned `""` for a
+  network error, a 5xx, a 404 and a genuinely undeprecated module alike. A
+  proxy outage during `--deprecated` therefore reported zero deprecations,
+  silently, and exited 0. Failures are now distinguished from definitive
+  answers (404 and 410 stay definitive), counted, and warned about.
+
+### Known gap
+
+- Vanity-import resolution (`--resolve`) does not yet contribute to the
+  incomplete count. `resolveOne` discovers a repository by reading a
+  `go-import` meta tag, and a failed request is not yet distinguishable from a
+  host that legitimately serves no tag. It reports zero failures rather than a
+  fabricated count.
+
 ## [0.10.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Five of the six formats — table, JSON, Markdown, quickfix, and SARIF — work 
 - `0` — no archived dependencies found
 - `1` — archived dependencies detected (useful in CI)
 - `2` — error (bad path, parse failure, API error)
+- `3` — scan incomplete: an upstream could not be reached, so the result is not
+  trustworthy. Takes precedence over `1` — a scan that could not check
+  everything does not know whether the project is clean, and partial data must
+  not be acted on. See the SARIF note below.
 
 ## Examples
 
@@ -446,13 +450,18 @@ $ modrot --sarif --deprecated > modrot.sarif
 ```
 
 ```yaml
-- run: modrot --sarif --deprecated > modrot.sarif || true
+- id: scan
+  run: |
+    modrot --sarif --deprecated > modrot.sarif || code=$?
+    echo "code=${code:-0}" >> "$GITHUB_OUTPUT"
+    [ "${code:-0}" = "2" ] && exit 1 || exit 0
 - uses: github/codeql-action/upload-sarif@v3
+  if: steps.scan.outputs.code != '3'
   with:
     sarif_file: modrot.sarif
 ```
 
-The `|| true` keeps the workflow running when modrot exits 1 on archived findings, so the upload step still runs. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the exact line that names it: the `require` line in `go.mod` for a Go unit, the `package.json` line for a direct npm dependency, the lockfile line (`package-lock.json` or `bun.lock`) for a transitive one. A dependency that appears in several manifests becomes one result with a location per site. SARIF paths are always relative to the current working directory, so run modrot from the repository root — e.g. `modrot --recursive --sarif . > modrot.sarif` — so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
+**Do not upload a SARIF run from an incomplete scan.** GitHub treats an uploaded run as the complete current state: a finding that is absent from it is marked resolved and its alert is closed. If an upstream registry is unreachable, modrot emits a short run — possibly an empty one — and uploading that would silently close alerts nobody fixed. That is why the scan exits `3` rather than `0`, and why the recipe above gates the upload on it instead of using a blanket `|| true`. Exit `1` (archived findings) still uploads, which is the normal case. Each archived dependency is reported as a `warning` and each deprecated dependency as a `note`, anchored to the exact line that names it: the `require` line in `go.mod` for a Go unit, the `package.json` line for a direct npm dependency, the lockfile line (`package-lock.json` or `bun.lock`) for a transitive one. A dependency that appears in several manifests becomes one result with a location per site. SARIF paths are always relative to the current working directory, so run modrot from the repository root — e.g. `modrot --recursive --sarif . > modrot.sarif` — so the paths are repo-relative. Stale, age, and stats sections are not part of SARIF output.
 
 **Sorting** — sort archived dependencies by field and direction. Append `:asc` or `:desc` to control order. Each field has a natural default:
 

--- a/config.go
+++ b/config.go
@@ -43,6 +43,12 @@ type Config struct {
 
 	// Time
 	Now time.Time // reference "now" for all time-relative calculations
+
+	// IncompleteLookups counts dependencies whose upstream metadata could not
+	// be retrieved — a network error, a 429, a 5xx. It is an absence of
+	// information, not a finding, and it changes the exit code so that CI
+	// never treats a partial scan as a clean one.
+	IncompleteLookups int
 }
 
 // DurationConfig controls the --duration feature.

--- a/deprecated.go
+++ b/deprecated.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,17 +16,19 @@ import (
 
 // CheckDeprecations fetches go.mod files from the proxy for all modules
 // and populates Module.Deprecated with the deprecation message if present.
-// Returns count of deprecated modules found.
-func CheckDeprecations(modules []Module, maxWorkers int) int {
+// Returns the count of deprecated modules found, and the count the proxy could
+// not be consulted about.
+func CheckDeprecations(modules []Module, maxWorkers int) (int, int) {
 	return checkDeprecationsWithResolver(modules, maxWorkers, newResolver())
 }
 
 // checkDeprecationsWithResolver is the internal implementation that accepts
 // a resolver, allowing tests to inject mock HTTP servers.
-func checkDeprecationsWithResolver(modules []Module, maxWorkers int, r *resolver) int {
+func checkDeprecationsWithResolver(modules []Module, maxWorkers int, r *resolver) (int, int) {
 	type result struct {
 		idx     int
 		message string
+		ok      bool
 	}
 	results := make(chan result, len(modules))
 
@@ -39,9 +42,9 @@ func checkDeprecationsWithResolver(modules []Module, maxWorkers int, r *resolver
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			msg := r.fetchGoModDeprecation(modules[idx].Path, modules[idx].Version)
-			if msg != "" {
-				results <- result{idx: idx, message: msg}
+			msg, ok := r.fetchGoModDeprecation(modules[idx].Path, modules[idx].Version)
+			if !ok || msg != "" {
+				results <- result{idx: idx, message: msg, ok: ok}
 			}
 		}(i)
 	}
@@ -49,20 +52,41 @@ func checkDeprecationsWithResolver(modules []Module, maxWorkers int, r *resolver
 	wg.Wait()
 	close(results)
 
-	count := 0
+	count, failed := 0, 0
 	for res := range results {
+		if !res.ok {
+			failed++
+			continue
+		}
 		modules[res.idx].Deprecated = res.message
 		count++
 	}
-	return count
+	warnIncompleteProxy(failed)
+	return count, failed
+}
+
+// warnIncompleteProxy reports modules the Go module proxy could not be
+// consulted about, mirroring warnIncomplete on the npm side.
+func warnIncompleteProxy(failed int) {
+	if failed == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(os.Stderr,
+		"Warning: could not reach the Go module proxy for %d %s; results are incomplete\n",
+		failed, pluralize(failed, "module", "modules"))
 }
 
 // fetchGoModDeprecation fetches a module's go.mod from the proxy and
 // extracts any "// Deprecated:" comment from the module directive.
-func (r *resolver) fetchGoModDeprecation(modulePath, version string) string {
+// The second return value is false only when the proxy could not be consulted
+// — a network error, a 429, a 5xx. A 404 or a 410 is a definitive "the proxy
+// has no go.mod for this version" and reports true with an empty message, as
+// does a module that simply carries no deprecation comment. Conflating the two
+// is what let a proxy outage report a clean scan.
+func (r *resolver) fetchGoModDeprecation(modulePath, version string) (string, bool) {
 	escaped, err := module.EscapePath(modulePath)
 	if err != nil {
-		return ""
+		return "", true // a path this malformed is not a transient condition
 	}
 
 	url := fmt.Sprintf("%s/%s/@v/%s.mod", r.proxyBaseURL, escaped, version)
@@ -71,25 +95,28 @@ func (r *resolver) fetchGoModDeprecation(modulePath, version string) string {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return ""
+		return "", false
 	}
 
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return ""
+		return "", false
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
-		return ""
+	switch {
+	case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+		return "", true // definitive: the proxy has no such module version
+	case resp.StatusCode != http.StatusOK:
+		return "", false
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return ""
+		return "", false
 	}
 
-	return parseDeprecation(string(body))
+	return parseDeprecation(string(body)), true
 }
 
 // parseDeprecation extracts the deprecation message from a go.mod file body.

--- a/deprecated_test.go
+++ b/deprecated_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -164,7 +165,7 @@ go 1.21
 			defer srv.Close()
 
 			r := &resolver{client: srv.Client(), proxyBaseURL: srv.URL}
-			got := r.fetchGoModDeprecation("github.com/golang/protobuf", "v1.5.4")
+			got, _ := r.fetchGoModDeprecation("github.com/golang/protobuf", "v1.5.4")
 			if got != tt.want {
 				t.Errorf("fetchGoModDeprecation() = %q, want %q", got, tt.want)
 			}
@@ -181,7 +182,7 @@ func TestFetchGoModDeprecation_CorrectURL(t *testing.T) {
 	defer srv.Close()
 
 	r := &resolver{client: srv.Client(), proxyBaseURL: srv.URL}
-	r.fetchGoModDeprecation("github.com/foo/bar", "v1.2.3")
+	_, _ = r.fetchGoModDeprecation("github.com/foo/bar", "v1.2.3")
 
 	wantPath := "/github.com/foo/bar/@v/v1.2.3.mod"
 	if gotPath != wantPath {
@@ -217,7 +218,7 @@ func TestCheckDeprecations(t *testing.T) {
 	// Manually check each module (simulating CheckDeprecations logic).
 	count := 0
 	for i := range modules {
-		msg := r.fetchGoModDeprecation(modules[i].Path, modules[i].Version)
+		msg, _ := r.fetchGoModDeprecation(modules[i].Path, modules[i].Version)
 		if msg != "" {
 			modules[i].Deprecated = msg
 			count++
@@ -265,7 +266,7 @@ func TestCheckDeprecations_WorkerPool(t *testing.T) {
 	}
 
 	r := &resolver{client: srv.Client(), proxyBaseURL: srv.URL}
-	count := checkDeprecationsWithResolver(modules, 4, r)
+	count, _ := checkDeprecationsWithResolver(modules, 4, r)
 
 	if count != 2 {
 		t.Errorf("count = %d, want 2", count)
@@ -281,5 +282,35 @@ func TestCheckDeprecations_WorkerPool(t *testing.T) {
 	}
 	if modules[3].Deprecated != "" {
 		t.Errorf("missing/mod should not be deprecated, got %q", modules[3].Deprecated)
+	}
+}
+
+// The Go proxy path returned "" for a network failure, a 5xx AND for "this
+// module has no deprecation comment" alike, so a proxy outage reported zero
+// deprecations with no warning and exit 0 — the same hazard as an empty SARIF
+// upload closing GitHub alerts. A failure must be counted, not swallowed.
+func TestCheckDeprecationsCountsUnreachableModules(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "good") {
+			_, _ = w.Write([]byte("// Deprecated: use something else\nmodule github.com/foo/good\n"))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := &resolver{client: srv.Client(), proxyBaseURL: srv.URL}
+	modules := []Module{
+		{Path: "github.com/foo/good", Version: "v1.0.0", Ecosystem: "go"},
+		{Path: "github.com/foo/unreachable", Version: "v1.0.0", Ecosystem: "go"},
+	}
+
+	found, failed := checkDeprecationsWithResolver(modules, 4, r)
+
+	if found != 1 {
+		t.Errorf("found %d deprecated, want 1", found)
+	}
+	if failed != 1 {
+		t.Errorf("failed = %d, want 1 — a 5xx must not read as 'no deprecation'", failed)
 	}
 }

--- a/ecosystem.go
+++ b/ecosystem.go
@@ -18,11 +18,14 @@ import (
 // npm, which is what makes --tree report itself unsupported rather than
 // needing a branch at the call site.
 type Ecosystem struct {
-	Name         string   // "go" or "npm"
-	Manifests    []string // primary manifest first, then companions
-	Parse        func(dir string) (*ParseResult, error)
-	Resolve      func(modules []Module) int
-	Deprecations func(modules []Module) int
+	Name      string   // "go" or "npm"
+	Manifests []string // primary manifest first, then companions
+	Parse     func(dir string) (*ParseResult, error)
+	// Resolve and Deprecations each return (count, failed): what they found,
+	// and how many dependencies their upstream could not be consulted about.
+	// The failure count is what stops an outage reading as a clean scan.
+	Resolve      func(modules []Module) (int, int)
+	Deprecations func(modules []Module) (int, int)
 	ScanImports  func(dir string, names []string) (map[string][]FileMatch, error)
 	Graph        func(dir, goVersionOverride string) (map[string][]string, error)
 }
@@ -50,8 +53,8 @@ var goEcosystem = &Ecosystem{
 	Name:         "go",
 	Manifests:    []string{"go.mod"},
 	Parse:        parseGoUnit,
-	Resolve:      func(m []Module) int { return ResolveVanityImports(m, 20) },
-	Deprecations: func(m []Module) int { return CheckDeprecations(m, 20) },
+	Resolve:      func(m []Module) (int, int) { return ResolveVanityImports(m, 20) },
+	Deprecations: func(m []Module) (int, int) { return CheckDeprecations(m, 20) },
 	ScanImports:  ScanImports,
 	Graph:        parseModGraph,
 }
@@ -277,13 +280,17 @@ func enrichUnits(units []manifestInfo, cfg *Config) {
 
 		if cfg.Resolve || eco.Name == "npm" {
 			// npm always resolves: repository.url is its only route to a repo.
-			if n := eco.Resolve(unique); n > 0 {
+			n, failed := eco.Resolve(unique)
+			cfg.IncompleteLookups += failed
+			if n > 0 {
 				_, _ = fmt.Fprintf(os.Stderr, "Resolved %d %s %s to GitHub repos.\n",
 					n, eco.Name, pluralize(n, "dependency", "dependencies"))
 			}
 		}
 		if cfg.Deprecated {
-			if n := eco.Deprecations(unique); n > 0 {
+			n, failed := eco.Deprecations(unique)
+			cfg.IncompleteLookups += failed
+			if n > 0 {
 				_, _ = fmt.Fprintf(os.Stderr, "Found %d deprecated %s %s.\n",
 					n, eco.Name, pluralize(n, "package", "packages"))
 			}

--- a/ecosystem_test.go
+++ b/ecosystem_test.go
@@ -204,14 +204,14 @@ func TestEnrichUnitsDeduplicatesAcrossUnits(t *testing.T) {
 	fake := &Ecosystem{
 		Name:      "go",
 		Manifests: []string{"go.mod"},
-		Resolve: func(mods []Module) int {
+		Resolve: func(mods []Module) (int, int) {
 			calls++
 			for i := range mods {
 				mods[i].Owner, mods[i].Repo = "acme", "shared"
 			}
-			return len(mods)
+			return len(mods), 0
 		},
-		Deprecations: func(mods []Module) int { return 0 },
+		Deprecations: func(mods []Module) (int, int) { return 0, 0 },
 	}
 	orig := ecosystems
 	ecosystems = []*Ecosystem{fake}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -156,5 +158,43 @@ func TestMixedRepoDiscovery(t *testing.T) {
 	}
 	if !names["go"] || !names["npm"] {
 		t.Errorf("discovered %v, want both go and npm", names)
+	}
+}
+
+// End-to-end proof of the incomplete-scan exit code: the whole pipeline, a
+// registry that answers 5xx for everything, and the exit status the CI job
+// actually sees. Asserting the counter alone would not prove the code reaches
+// os.Exit — which is the entire point of the fix.
+func TestIncompleteScanExitsThreeEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"),
+		[]byte(`{"name":"outage-check","dependencies":{"xterm":"^5.3.0"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(down.Close)
+
+	orig := npmRegistry
+	npmRegistry = newNPMClient()
+	npmRegistry.baseURL = down.URL
+	t.Cleanup(func() { npmRegistry = orig })
+
+	cfg := defaultTestConfig()
+	cfg.Deprecated = true
+	cfg.OutputFormat = "table"
+
+	var got int
+	_ = captureStdout(t, func() {
+		got = runSingleModule(cfg, dir)
+	})
+
+	if got != 3 {
+		t.Errorf("exit code = %d, want 3 — an unreachable registry must not report a clean scan", got)
+	}
+	if cfg.IncompleteLookups == 0 {
+		t.Error("IncompleteLookups = 0, want >0")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -96,7 +96,8 @@ Detect archived GitHub dependencies in a Go, npm, or Bun project.
 
 With no flags, checks the go.mod and/or package.json in the current
 directory and prints archived dependencies as a table. Exits 1 if any
-are found (useful for CI).
+are found (useful for CI), 2 on error, and 3 if an upstream could not
+be reached and the scan is therefore incomplete.
 Flags can appear before or after the path argument.
 
 Output format:
@@ -297,10 +298,7 @@ func reportUnits(units []manifestInfo, cfg *Config, rootDir string) int {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 2
 	}
-	if dispatchRecursiveOutput(units, statusMap, cfg) {
-		return 1
-	}
-	return 0
+	return exitCode(cfg, dispatchRecursiveOutput(units, statusMap, cfg))
 }
 
 // runSingleUnit runs the full pipeline for a single manifest unit, printing
@@ -334,7 +332,7 @@ func runSingleUnit(mi manifestInfo, cfg *Config) int {
 				Deprecated:  collectDeprecated(cfg, mi.allModules),
 			}})
 		}
-		return 0
+		return exitCode(cfg, false)
 	}
 
 	_, _ = fmt.Fprintf(os.Stderr, "Checking %d GitHub modules...\n", len(githubModules))
@@ -376,7 +374,7 @@ func runSingleUnit(mi manifestInfo, cfg *Config) int {
 			_, _ = fmt.Fprintf(os.Stderr, "Warning: could not run go mod graph: %v\n", graphErr)
 		} else {
 			outputTree(cfg, results, graph, mi.allModules, fileMatches, nonGitHubModules, deprecatedModules, stale, ignoredResults, ignoreList)
-			return exitCode(hasArchived)
+			return exitCode(cfg, hasArchived)
 		}
 	}
 
@@ -385,13 +383,13 @@ func runSingleUnit(mi manifestInfo, cfg *Config) int {
 	// would print a text table into the middle of that document.
 	// warnUnsupported has already explained the omission.
 	if cfg.OutputFormat == "mermaid" && mi.eco.Graph == nil {
-		return exitCode(hasArchived)
+		return exitCode(cfg, hasArchived)
 	}
 
 	// Output
 	outputFlat(cfg, unitDirFromCwd(cwd, mi.manifestPath), results, nonGitHubModules, fileMatches, deprecatedModules, stale, ignoredResults, ignoreList)
 
-	return exitCode(hasArchived)
+	return exitCode(cfg, hasArchived)
 }
 
 // splitUnitModules runs a unit's Go freshness pass, when requested, and then
@@ -559,8 +557,17 @@ func outputSupplement(cfg *Config, results []RepoStatus, nonGitHubModules []Modu
 	}
 }
 
-// exitCode returns 1 if archived deps were found, 0 otherwise.
-func exitCode(hasArchived bool) int {
+// exitCode maps a finished scan to its exit status: 3 if any lookup could not
+// be completed, 1 if archived dependencies were found, 0 otherwise.
+//
+// Incompleteness outranks a finding. A scan that could not reach the registry
+// does not know what it missed, and the caller must not act on partial data —
+// most sharply under --sarif, where uploading a short run lets GitHub close
+// alerts that were never re-verified.
+func exitCode(cfg *Config, hasArchived bool) int {
+	if cfg.IncompleteLookups > 0 {
+		return 3
+	}
 	if hasArchived {
 		return 1
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -237,3 +237,31 @@ func TestExtractStaleFlag_WithThreshold(t *testing.T) {
 		t.Errorf("threshold = (%d, %d, %d), want (1, 6, 0)", staleCfg.Years, staleCfg.Months, staleCfg.Days)
 	}
 }
+
+// A scan that could not reach the registry does not know whether the project
+// is clean. Reporting 0 lets a CI job upload an empty SARIF run, which GitHub
+// reads as "resolved" and uses to close existing alerts — an outage silently
+// clearing a repo's findings. Incompleteness outranks "archived deps found"
+// for the same reason: partial data must not be acted on.
+func TestExitCodeIncompleteOutranksFindings(t *testing.T) {
+	tests := []struct {
+		name        string
+		incomplete  int
+		hasArchived bool
+		want        int
+	}{
+		{"clean and complete", 0, false, 0},
+		{"archived deps, complete", 0, true, 1},
+		{"clean but incomplete", 3, false, 3},
+		{"archived deps AND incomplete", 3, true, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{IncompleteLookups: tt.incomplete}
+			if got := exitCode(cfg, tt.hasArchived); got != tt.want {
+				t.Errorf("exitCode(incomplete=%d, archived=%v) = %d, want %d",
+					tt.incomplete, tt.hasArchived, got, tt.want)
+			}
+		})
+	}
+}

--- a/npmregistry.go
+++ b/npmregistry.go
@@ -169,13 +169,13 @@ var npmRegistry = newNPMClient()
 // ResolveNPM populates Owner and Repo on npm modules from the registry's
 // repository field, and fills in the resolved version for unlocked units.
 // Returns the count resolved to a GitHub repo.
-func ResolveNPM(modules []Module) int {
+func ResolveNPM(modules []Module) (int, int) {
 	return resolveNPMWithClient(modules, npmRegistry)
 }
 
 // CheckNPMDeprecations populates Deprecated on npm modules from the registry.
 // Returns the count of deprecated packages found.
-func CheckNPMDeprecations(modules []Module) int {
+func CheckNPMDeprecations(modules []Module) (int, int) {
 	return checkNPMDeprecationsWithClient(modules, npmRegistry)
 }
 
@@ -285,7 +285,7 @@ func warnMissing(missing []string) {
 
 // resolveNPMWithClient is the internal implementation, accepting a client so
 // tests can point at a mock registry.
-func resolveNPMWithClient(modules []Module, c *npmClient) int {
+func resolveNPMWithClient(modules []Module, c *npmClient) (int, int) {
 	resolved, failed, missing := npmFetchAll(modules, c, func(m *Module, info *npmVersionInfo) bool {
 		if m.Version == "" && info.Version != "" {
 			m.Version = info.Version
@@ -301,12 +301,12 @@ func resolveNPMWithClient(modules []Module, c *npmClient) int {
 	})
 	warnIncomplete(failed)
 	warnMissing(missing)
-	return resolved
+	return resolved, failed
 }
 
 // checkNPMDeprecationsWithClient is the internal implementation, accepting a
 // client so tests can point at a mock registry.
-func checkNPMDeprecationsWithClient(modules []Module, c *npmClient) int {
+func checkNPMDeprecationsWithClient(modules []Module, c *npmClient) (int, int) {
 	found, failed, missing := npmFetchAll(modules, c, func(m *Module, info *npmVersionInfo) bool {
 		if info.Deprecated == "" {
 			return false
@@ -322,7 +322,7 @@ func checkNPMDeprecationsWithClient(modules []Module, c *npmClient) int {
 	// a package's deprecation status silently unchecked.
 	warnIncomplete(failed)
 	warnMissing(missing)
-	return found
+	return found, failed
 }
 
 // markReported records that a missing package has been warned about and

--- a/npmregistry_test.go
+++ b/npmregistry_test.go
@@ -90,7 +90,7 @@ func TestResolveNPMPopulatesOwnerRepo(t *testing.T) {
 		{Path: "norepo", Version: "1.0.0", Ecosystem: "npm"},
 		{Path: "missing", Version: "9.9.9", Ecosystem: "npm"},
 	}
-	got := resolveNPMWithClient(mods, c)
+	got, _ := resolveNPMWithClient(mods, c)
 	if got != 4 {
 		t.Errorf("resolved %d, want 4", got)
 	}
@@ -121,7 +121,7 @@ func TestCheckNPMDeprecations(t *testing.T) {
 		{Path: "circular-json", Version: "0.5.9", Ecosystem: "npm"},
 		{Path: "norepo", Version: "1.0.0", Ecosystem: "npm"},
 	}
-	got := checkNPMDeprecationsWithClient(mods, c)
+	got, _ := checkNPMDeprecationsWithClient(mods, c)
 	if got != 2 {
 		t.Errorf("found %d deprecated, want 2", got)
 	}
@@ -144,7 +144,7 @@ func TestResolveNPMUnlockedUsesLatest(t *testing.T) {
 	c.baseURL = srv.URL
 
 	mods := []Module{{Path: "xterm", Version: "", Ecosystem: "npm"}}
-	if got := resolveNPMWithClient(mods, c); got != 1 {
+	if got, _ := resolveNPMWithClient(mods, c); got != 1 {
 		t.Fatalf("resolved %d, want 1", got)
 	}
 	if mods[0].Version != "5.3.0" {
@@ -175,7 +175,7 @@ func TestNPMClientScopedNames(t *testing.T) {
 	c.baseURL = srv.URL
 
 	mods := []Module{{Path: "@babel/core", Version: "7.24.0", Ecosystem: "npm"}}
-	if got := resolveNPMWithClient(mods, c); got != 1 {
+	if got, _ := resolveNPMWithClient(mods, c); got != 1 {
 		t.Fatalf("resolved %d, want 1", got)
 	}
 	if gotURI != "/@babel/core/7.24.0" {
@@ -250,7 +250,7 @@ func TestResolveNPMReportsUnreachablePackages(t *testing.T) {
 		{Path: "good", Version: "1.0.0", Ecosystem: "npm"},
 		{Path: "unreachable", Version: "1.0.0", Ecosystem: "npm"},
 	}
-	if got := resolveNPMWithClient(mods, c); got != 1 {
+	if got, _ := resolveNPMWithClient(mods, c); got != 1 {
 		t.Errorf("resolved %d, want 1", got)
 	}
 	if mods[0].Owner != "foo" {
@@ -278,7 +278,7 @@ func TestCheckNPMDeprecationsReportsUnreachablePackages(t *testing.T) {
 	c.baseURL = srv.URL
 
 	mods := []Module{{Path: "unreachable", Version: "1.0.0", Ecosystem: "npm"}}
-	if got := checkNPMDeprecationsWithClient(mods, c); got != 0 {
+	if got, _ := checkNPMDeprecationsWithClient(mods, c); got != 0 {
 		t.Errorf("found %d deprecated, want 0", got)
 	}
 	if hits == 0 {
@@ -327,7 +327,7 @@ func TestResolveNPMMarksInferredVersion(t *testing.T) {
 		{Path: "xterm", Version: "", Ecosystem: "npm"},
 		{Path: "xterm", Version: "5.3.0", Ecosystem: "npm"},
 	}
-	if got := resolveNPMWithClient(mods, c); got != 2 {
+	if got, _ := resolveNPMWithClient(mods, c); got != 2 {
 		t.Fatalf("resolved %d, want 2", got)
 	}
 	if !mods[0].VersionInferred {
@@ -376,7 +376,7 @@ func TestNonRegistryDepsAreNeverRequested(t *testing.T) {
 		{Path: "ui", Version: "", Ecosystem: "npm", NonRegistry: true},
 		{Path: "shared", Version: "", Ecosystem: "npm", NonRegistry: true},
 	}
-	_ = captureStderr(t, func() { resolveNPMWithClient(mods, c) })
+	_ = captureStderr(t, func() { _, _ = resolveNPMWithClient(mods, c) })
 
 	if len(requested) != 0 {
 		t.Errorf("registry was asked about non-registry deps: %v", requested)
@@ -403,7 +403,7 @@ func TestMissingRegistryPackagesAreReported(t *testing.T) {
 		{Path: "good", Version: "1.0.0", Ecosystem: "npm"},
 		{Path: "typosquatted", Version: "1.0.0", Ecosystem: "npm"},
 	}
-	stderr := captureStderr(t, func() { resolveNPMWithClient(mods, c) })
+	stderr := captureStderr(t, func() { _, _ = resolveNPMWithClient(mods, c) })
 
 	if !strings.Contains(stderr, "typosquatted") {
 		t.Errorf("missing package not named on stderr, got: %q", stderr)
@@ -427,8 +427,8 @@ func TestMissingPackageReportedOncePerRun(t *testing.T) {
 
 	mods := []Module{{Path: "ghost-package", Version: "1.0.0", Ecosystem: "npm"}}
 	stderr := captureStderr(t, func() {
-		resolveNPMWithClient(mods, c)
-		checkNPMDeprecationsWithClient(mods, c)
+		_, _ = resolveNPMWithClient(mods, c)
+		_, _ = checkNPMDeprecationsWithClient(mods, c)
 	})
 
 	if got := strings.Count(stderr, "ghost-package"); got != 1 {

--- a/recursive.go
+++ b/recursive.go
@@ -143,10 +143,7 @@ func runRecursive(rootDir string, cfg *Config) int {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 2
 	}
-	if dispatchRecursiveOutput(modules, statusMap, cfg) {
-		return 1
-	}
-	return 0
+	return exitCode(cfg, dispatchRecursiveOutput(modules, statusMap, cfg))
 }
 
 // prepareUnits runs the freshness pass, when requested, then splits every unit

--- a/resolve.go
+++ b/resolve.go
@@ -45,9 +45,17 @@ func newResolver() *resolver {
 }
 
 // ResolveVanityImports resolves non-GitHub modules to GitHub repos.
-// It updates Owner/Repo in-place on each Module. Returns the count resolved.
-func ResolveVanityImports(modules []Module, maxWorkers int) int {
-	return resolveVanityImportsWithResolver(modules, maxWorkers, newResolver())
+// It updates Owner/Repo in-place on each Module.
+//
+// Returns (resolved, incomplete). The incomplete count is always 0 today:
+// resolveOne discovers a repo by fetching a vanity URL and reading its
+// go-import meta tag, and "the request failed" is not yet distinguishable from
+// "this host serves no meta tag" — which is a legitimate answer for many
+// modules. Reporting a fabricated failure count would be worse than reporting
+// none, so this path does not yet contribute to the incomplete-scan exit code.
+// See the note in the changelog.
+func ResolveVanityImports(modules []Module, maxWorkers int) (int, int) {
+	return resolveVanityImportsWithResolver(modules, maxWorkers, newResolver()), 0
 }
 
 // resolveVanityImportsWithResolver is the internal implementation that accepts


### PR DESCRIPTION
Closes the last item carried out of #23.

## The hazard

An unreachable upstream warned on stderr and still exited `0`. Under `--sarif` in CI
that uploaded a short — possibly empty — run, and GitHub treats an uploaded run as the
complete current state: findings absent from it are marked resolved. So a registry
outage could silently close alerts nobody had fixed.

## What changed

- **New exit code `3`** — scan incomplete. It **outranks `1`**: a scan that could not
  check everything does not know whether the project is clean, so partial data must not
  be acted on.
- **The Go proxy path could not report a failure at all.** `fetchGoModDeprecation`
  returned `""` for a network error, a 5xx, a 404 and a genuinely undeprecated module
  alike, so a proxy outage during `--deprecated` reported zero deprecations silently.
  Failures are now distinguished from definitive answers (404/410 stay definitive),
  counted, and warned about — mirroring the npm side.
- The `Ecosystem` seam's `Resolve` and `Deprecations` now return `(count, failed)`, so
  both ecosystems feed one counter on `Config`.
- The README's CI recipe gated the upload on `|| true`, which would have swallowed `3`
  and uploaded the empty run anyway. It now gates on the exit code.

## Known gap, deliberately left

Vanity-import resolution (`--resolve`) contributes zero failures. `resolveOne` reads a
`go-import` meta tag, and a failed request is not yet distinguishable from a host that
legitimately serves none. Reporting a fabricated count would be worse than reporting
none; it is documented in the changelog rather than papered over.

## Verification

- `make verify` clean, lint 0 issues.
- End-to-end test drives the **whole pipeline** against a registry answering 5xx and
  asserts the exit status, rather than asserting the counter — the point of the fix is
  that the code reaches `os.Exit`.
- Go regression gate: binary built from `v0.10.0` vs this branch over openbao,
  byte-identical stdout, stderr and exit code across `--json`, `--json --deprecated`,
  `--quickfix`, `--sarif --deprecated`, `--deprecated --stats`,
  `--markdown --all --deprecated`.

Exit `3` is a new code rather than a reuse of `2`, and it is a behaviour change for any
CI that distinguishes exit statuses — worth a look before merge.