### PR TITLE
Stamp changelog for v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ are always called out under **BREAKING** below.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-14
+
 ### Added
 
 - Exit code `3` — scan incomplete. An upstream that could not be reached
@@ -243,7 +245,8 @@ First tagged release, as `modrot`.
 - Flags were ignored when placed after the `go.mod` path.
 - `--deprecated` findings were missing from `--tree --json` output.
 
-[Unreleased]: https://github.com/norman-abramovitz/modrot/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/norman-abramovitz/modrot/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/norman-abramovitz/modrot/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/norman-abramovitz/modrot/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/norman-abramovitz/modrot/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/norman-abramovitz/modrot/compare/v0.7.0...v0.8.0


### PR DESCRIPTION
Release chore ahead of tagging `v0.11.0`. No code change.

**Minor, not patch.** Exit code `3` means a scan that previously exited `0` can now
fail a pipeline — a behaviour change for every CI consumer, so `v0.10.1` would
understate it.

Moves the accumulated `[Unreleased]` entries under `## [0.11.0] - 2026-08-14`, adds the
compare link, and leaves an empty `[Unreleased]` for the next cycle.

Merge this and `v0.11.0` gets tagged on `main`; the tag push triggers GoReleaser.