### PR TITLE
composite github action producing sarif

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,34 @@
+name: action-smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: scan
+        uses: ./
+      - name: assert outputs
+        shell: bash
+        env:
+          SARIF: ${{ steps.scan.outputs.sarif-file }}
+          CODE: ${{ steps.scan.outputs.exit-code }}
+        run: |
+          set -euo pipefail
+          [ -s "$SARIF" ] || { echo "::error::SARIF file missing or empty"; exit 1; }
+          jq -e '.runs[0].tool.driver.name == "modrot"' "$SARIF" >/dev/null
+          case "$CODE" in
+            0|1|3) echo "exit-code=$CODE (ok)" ;;
+            *) echo "::error::unexpected exit-code $CODE"; exit 1 ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -475,6 +475,8 @@ Without the Action, the same recipe by hand:
 
 ```yaml
 - id: scan
+  env:
+    GH_TOKEN: ${{ github.token }}
   run: |
     modrot --sarif --deprecated > modrot.sarif || code=$?
     echo "code=${code:-0}" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -449,6 +449,30 @@ deprecated dependencies appear in the repository's Security tab:
 $ modrot --sarif --deprecated > modrot.sarif
 ```
 
+The easiest way to run this in CI is the bundled GitHub Action, which
+downloads a pinned release binary (checksum-verified), runs the scan, and
+exposes the SARIF path and exit code as outputs:
+
+```yaml
+- id: scan
+  uses: norman-abramovitz/modrot@v0.12.0
+- uses: github/codeql-action/upload-sarif@v3
+  if: steps.scan.outputs.exit-code != '3'
+  with:
+    sarif_file: ${{ steps.scan.outputs.sarif-file }}
+```
+
+Inputs (all optional): `working-directory` (default `.`), `recursive`
+(default `false`), `deprecated` (default `true`), `sarif-file` (default
+`modrot.sarif`), `version` (release to download), `extra-args` (appended
+verbatim, e.g. `--resolve`), and `github-token` (defaults to the workflow
+token; exported as `GH_TOKEN`). Linux and macOS runners only. The step
+fails only when modrot itself errors (exit 2); exit 1 (findings) and
+exit 3 (incomplete scan) succeed so that you own the gate — as above,
+never upload when `exit-code` is `3`.
+
+Without the Action, the same recipe by hand:
+
 ```yaml
 - id: scan
   run: |

--- a/action.yml
+++ b/action.yml
@@ -98,12 +98,13 @@ runs:
         if [ "$MODROT_DEPRECATED" = "true" ]; then args+=(--deprecated); fi
         if [ "$MODROT_RECURSIVE" = "true" ]; then args+=(--recursive); fi
         code=0
-        # extra-args is word-split by design
+        # extra-args is word-split by design, but not glob-expanded
+        set -f
         modrot "${args[@]}" $MODROT_EXTRA_ARGS . > "$MODROT_SARIF_FILE" || code=$?
         echo "exit-code=${code}" >> "$GITHUB_OUTPUT"
         echo "sarif-file=${MODROT_WORKDIR%/}/${MODROT_SARIF_FILE}" >> "$GITHUB_OUTPUT"
-        if [ "$code" = "2" ]; then
-          echo "::error::modrot exited 2 (error) — see log above"
-          exit 1
-        fi
-        exit 0
+        case "$code" in
+          0|1|3) exit 0 ;;
+          2) echo "::error::modrot exited 2 (error) — see log above"; exit 1 ;;
+          *) echo "::error::unexpected modrot exit $code"; exit 1 ;;
+        esac

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,109 @@
+name: modrot
+description: >-
+  Detect archived and deprecated dependencies in Go, npm, and Bun projects
+  and write a SARIF report for GitHub code scanning.
+
+inputs:
+  working-directory:
+    description: >-
+      Directory to scan. SARIF paths are relative to this directory, so
+      keep it at the repository root for code-scanning uploads.
+    required: false
+    default: "."
+  recursive:
+    description: Scan every manifest in the directory tree (monorepos).
+    required: false
+    default: "false"
+  deprecated:
+    description: Also check for deprecated modules and packages.
+    required: false
+    default: "true"
+  sarif-file:
+    description: SARIF output path, relative to working-directory.
+    required: false
+    default: "modrot.sarif"
+  version:
+    description: modrot release tag to download.
+    required: false
+    default: "v0.11.0"
+  extra-args:
+    description: Extra modrot flags, appended verbatim (e.g. "--resolve").
+    required: false
+    default: ""
+  github-token:
+    description: Token exported as GH_TOKEN so modrot can query the GitHub API.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  sarif-file:
+    description: Path of the SARIF file that was written.
+    value: ${{ steps.scan.outputs.sarif-file }}
+  exit-code:
+    description: >-
+      modrot exit code. 0 clean, 1 archived dependencies found, 2 error,
+      3 scan incomplete — do not upload the SARIF when it is 3.
+    value: ${{ steps.scan.outputs.exit-code }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        MODROT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        command -v gh >/dev/null 2>&1 || {
+          echo "::error::GitHub CLI (gh) is required — modrot reads its token via 'gh auth token'"
+          exit 1
+        }
+        case "$(uname -s)" in
+          Linux)  os=linux ;;
+          Darwin) os=darwin ;;
+          *) echo "::error::modrot supports Linux and macOS runners, got $(uname -s)"; exit 1 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64|amd64)  arch=amd64 ;;
+          aarch64|arm64) arch=arm64 ;;
+          *) echo "::error::unsupported architecture $(uname -m)"; exit 1 ;;
+        esac
+        ver="${MODROT_VERSION#v}"
+        asset="modrot_${ver}_${os}_${arch}.tar.gz"
+        base="https://github.com/norman-abramovitz/modrot/releases/download/${MODROT_VERSION}"
+        dir="$(mktemp -d)"
+        curl -fsSL --retry 3 -o "${dir}/${asset}"      "${base}/${asset}"
+        curl -fsSL --retry 3 -o "${dir}/checksums.txt" "${base}/checksums.txt"
+        cd "$dir"
+        if command -v sha256sum >/dev/null 2>&1; then
+          grep " ${asset}\$" checksums.txt | sha256sum -c -
+        else
+          grep " ${asset}\$" checksums.txt | shasum -a 256 -c -
+        fi
+        tar -xzf "$asset" modrot
+        echo "$dir" >> "$GITHUB_PATH"
+    - id: scan
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        MODROT_DEPRECATED: ${{ inputs.deprecated }}
+        MODROT_RECURSIVE: ${{ inputs.recursive }}
+        MODROT_SARIF_FILE: ${{ inputs.sarif-file }}
+        MODROT_EXTRA_ARGS: ${{ inputs.extra-args }}
+        MODROT_WORKDIR: ${{ inputs.working-directory }}
+      run: |
+        set -uo pipefail
+        args=(--sarif)
+        if [ "$MODROT_DEPRECATED" = "true" ]; then args+=(--deprecated); fi
+        if [ "$MODROT_RECURSIVE" = "true" ]; then args+=(--recursive); fi
+        code=0
+        # extra-args is word-split by design
+        modrot "${args[@]}" $MODROT_EXTRA_ARGS . > "$MODROT_SARIF_FILE" || code=$?
+        echo "exit-code=${code}" >> "$GITHUB_OUTPUT"
+        echo "sarif-file=${MODROT_WORKDIR%/}/${MODROT_SARIF_FILE}" >> "$GITHUB_OUTPUT"
+        if [ "$code" = "2" ]; then
+          echo "::error::modrot exited 2 (error) — see log above"
+          exit 1
+        fi
+        exit 0


### PR DESCRIPTION
Adds a composite Action at the repo root (uses: norman-abramovitz/modrot@<tag>):
downloads a pinned, checksum-verified release binary, runs the scan, and exposes
sarif-file and exit-code outputs. The step fails on exit 2 and on any unexpected
exit code; exit 3 (incomplete scan) is surfaced for the caller's upload gate,
never swallowed. Smoke workflow runs the action against this repo on linux and
macos. README CI section now leads with the Action; manual recipe kept (and now
sets GH_TOKEN so it authenticates on runners).

Notes:
- action.yml version input defaults to v0.11.0 (newest downloadable release);
  the v0.12.0 release-prep PR bumps it alongside the changelog stamp.
- README example pins @v0.12.0, the first tag that will contain action.yml.