### PR TITLE
release v0.12.0

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/checkout@v4
       - id: scan
         uses: ./
+        with:
+          # newest published release — the action's own default may name a tag
+          # whose release does not exist yet while its stamp PR is in flight
+          version: v0.11.0
       - name: assert outputs
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ are always called out under **BREAKING** below.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-15
+
+### Added
+
+- A composite GitHub Action, published from this repository's root:
+  `uses: norman-abramovitz/modrot@v0.12.0`. It downloads the pinned release
+  binary (sha256-verified against `checksums.txt`), runs the scan with
+  `--sarif`, and exposes two outputs for the caller's upload gate:
+  `sarif-file` (the report path) and `exit-code` (`0` clean, `1` archived
+  found, `2` error, `3` scan incomplete — do not upload). The step fails only
+  when modrot itself errors: exit `2`, or any unexpected exit code from a
+  crashed process. Exit `1` and `3` succeed so the caller owns the gate.
+  Inputs: `working-directory`, `recursive`, `deprecated` (default `true`),
+  `sarif-file`, `version`, `extra-args`, and `github-token` (exported as
+  `GH_TOKEN` for the GitHub API). Linux and macOS runners.
+- A smoke workflow that runs the Action against this repository on Linux and
+  macOS on every pull request and push to `main`.
+
+### Changed
+
+- The README's CI recipe now leads with the Action; the hand-rolled recipe is
+  kept as the "Without the Action" variant and now sets `GH_TOKEN`, without
+  which a runner queries the GitHub API unauthenticated at 60 requests/hour
+  and tends to produce spurious incomplete-scan exits.
+
 ## [0.11.0] - 2026-08-14
 
 ### Added
@@ -245,7 +270,8 @@ First tagged release, as `modrot`.
 - Flags were ignored when placed after the `go.mod` path.
 - `--deprecated` findings were missing from `--tree --json` output.
 
-[Unreleased]: https://github.com/norman-abramovitz/modrot/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/norman-abramovitz/modrot/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/norman-abramovitz/modrot/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/norman-abramovitz/modrot/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/norman-abramovitz/modrot/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/norman-abramovitz/modrot/compare/v0.8.0...v0.9.0

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   version:
     description: modrot release tag to download.
     required: false
-    default: "v0.11.0"
+    default: "v0.12.0"
   extra-args:
     description: Extra modrot flags, appended verbatim (e.g. "--resolve").
     required: false


### PR DESCRIPTION
Release prep for v0.12.0 (the composite GitHub Action).

- Changelog stamped: [0.12.0] - 2026-08-15 (Action + smoke workflow under
  Added; README CI recipe changes under Changed).
- action.yml version input default bumped v0.11.0 -> v0.12.0 so the Action
  ref and the binary it downloads agree at the tag.
- Smoke workflow now pins version: v0.11.0 (newest published release) —
  without the pin, this PR's own smoke run would try to download v0.12.0,
  which does not exist until the tag is cut. The pin stays n-1 and bumps in
  each stamp PR.

After merge: tag v0.12.0 on main and verify the release run, the published
assets, and the Homebrew cask bump.